### PR TITLE
Rename crate to text-processing-rs for crates.io publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,14 +182,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "nemo-text-processing"
-version = "0.1.0"
-dependencies = [
- "lazy_static",
- "proptest",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +403,14 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "text-processing-rs"
+version = "0.1.0"
+dependencies = [
+ "lazy_static",
+ "proptest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "nemo-text-processing"
+name = "text-processing-rs"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
-description = "Rust port of NVIDIA NeMo Text Processing for Inverse Text Normalization"
-repository = "https://github.com/FluidInference/NeMo-text-processing-rs"
-keywords = ["asr", "speech", "normalization", "nlp", "nemo"]
+description = "Inverse Text Normalization (ITN) — convert spoken-form ASR output to written form"
+repository = "https://github.com/FluidInference/text-processing-rs"
+keywords = ["asr", "speech", "normalization", "nlp", "itn"]
 categories = ["text-processing"]
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # text-processing-rs
 
-A Rust port of [NVIDIA NeMo Text Processing](https://github.com/NVIDIA/NeMo-text-processing) for Inverse Text Normalization (ITN).
+Inverse Text Normalization (ITN) for Rust — convert spoken-form ASR output to written form.
 
 ## What it does
 
@@ -20,7 +20,7 @@ Converts spoken-form ASR output to written form:
 ### Rust
 
 ```rust
-use nemo_text_processing::normalize;
+use text_processing_rs::normalize;
 
 let result = normalize("two hundred");
 assert_eq!(result, "200");
@@ -43,7 +43,7 @@ let money = NemoTextProcessing.normalize("five dollars and fifty cents")
 
 ## Compatibility
 
-**98.6% compatible** with NeMo text processing test suite (1200/1217 tests passing).
+**98.6% compatible** with the original NeMo test suite (1200/1217 tests passing).
 
 | Category | Status |
 |----------|--------|
@@ -96,7 +96,7 @@ Output:
 
 ## License
 
-Apache 2.0 (same as [NeMo Text Processing](https://github.com/NVIDIA/NeMo-text-processing))
+Apache 2.0
 
 ## Acknowledgments
 

--- a/build-xcframework.sh
+++ b/build-xcframework.sh
@@ -26,17 +26,17 @@ cargo build --release --features ffi --target aarch64-apple-ios-sim
 echo "Creating universal macOS library..."
 mkdir -p "$BUILD_DIR/macos"
 lipo -create \
-    target/aarch64-apple-darwin/release/libnemo_text_processing.a \
-    target/x86_64-apple-darwin/release/libnemo_text_processing.a \
-    -output "$BUILD_DIR/macos/libnemo_text_processing.a"
+    target/aarch64-apple-darwin/release/libtext_processing_rs.a \
+    target/x86_64-apple-darwin/release/libtext_processing_rs.a \
+    -output "$BUILD_DIR/macos/libtext_processing_rs.a"
 
 echo "Creating XCFramework..."
 xcodebuild -create-xcframework \
-    -library "$BUILD_DIR/macos/libnemo_text_processing.a" \
+    -library "$BUILD_DIR/macos/libtext_processing_rs.a" \
     -headers swift/include \
-    -library target/aarch64-apple-ios/release/libnemo_text_processing.a \
+    -library target/aarch64-apple-ios/release/libtext_processing_rs.a \
     -headers swift/include \
-    -library target/aarch64-apple-ios-sim/release/libnemo_text_processing.a \
+    -library target/aarch64-apple-ios-sim/release/libtext_processing_rs.a \
     -headers swift/include \
     -output "$OUTPUT_DIR/NemoTextProcessing.xcframework"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
-//! # NeMo-text-processing-rs
+//! # text-processing-rs
 //!
-//! Rust port of NVIDIA NeMo Text Processing for Inverse Text Normalization.
+//! Inverse Text Normalization (ITN) — convert spoken-form ASR output to written form.
 //!
 //! Converts spoken-form text to written form:
 //! - "two hundred thirty two" → "232"
@@ -10,7 +10,7 @@
 //! ## Usage
 //!
 //! ```
-//! use nemo_text_processing::normalize;
+//! use text_processing_rs::normalize;
 //!
 //! let result = normalize("two hundred");
 //! assert_eq!(result, "200");
@@ -178,7 +178,7 @@ fn parse_span(span: &str) -> Option<(String, u8)> {
 /// Uses a default max span of 16 tokens.
 ///
 /// ```
-/// use nemo_text_processing::normalize_sentence;
+/// use text_processing_rs::normalize_sentence;
 ///
 /// assert_eq!(normalize_sentence("I have twenty one apples"), "I have 21 apples");
 /// assert_eq!(normalize_sentence("hello world"), "hello world");
@@ -195,7 +195,7 @@ pub fn normalize_sentence(input: &str) -> String {
 /// Larger values catch more patterns but do more work per token.
 ///
 /// ```
-/// use nemo_text_processing::normalize_sentence_with_max_span;
+/// use text_processing_rs::normalize_sentence_with_max_span;
 ///
 /// // Short span: only catches small expressions
 /// assert_eq!(normalize_sentence_with_max_span("I have twenty one apples", 4), "I have 21 apples");

--- a/swift-test/Package.swift
+++ b/swift-test/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
             dependencies: ["CNemoTextProcessing"],
             linkerSettings: [
                 .unsafeFlags([
-                    "-L/Users/kikow/brandon/voicelink/NeMo-text-processing-rs/target/aarch64-apple-darwin/release",
-                    "-lnemo_text_processing"
+                    "-L/Users/kikow/brandon/voicelink/text-processing-rs/target/aarch64-apple-darwin/release",
+                    "-ltext_processing_rs"
                 ])
             ]
         ),

--- a/swift-test/Sources/CNemoTextProcessing/module.modulemap
+++ b/swift-test/Sources/CNemoTextProcessing/module.modulemap
@@ -1,5 +1,5 @@
 module CNemoTextProcessing {
     header "include/nemo_text_processing.h"
-    link "nemo_text_processing"
+    link "text_processing_rs"
     export *
 }

--- a/tests/en_tests.rs
+++ b/tests/en_tests.rs
@@ -1,11 +1,11 @@
 //! English inverse text normalization tests.
 //!
-//! Test cases sourced from NeMo text processing:
+//! Test cases sourced from NVIDIA NeMo text processing:
 //! https://github.com/NVIDIA/NeMo-text-processing
 
 mod common;
 
-use nemo_text_processing::{
+use text_processing_rs::{
     custom_rules, normalize, normalize_sentence, normalize_sentence_with_max_span,
 };
 use std::path::Path;

--- a/tests/en_tests.rs
+++ b/tests/en_tests.rs
@@ -5,10 +5,10 @@
 
 mod common;
 
+use std::path::Path;
 use text_processing_rs::{
     custom_rules, normalize, normalize_sentence, normalize_sentence_with_max_span,
 };
-use std::path::Path;
 
 fn print_failures(results: &common::TestResults) {
     for f in &results.failures {


### PR DESCRIPTION
## Summary
- Rename crate from `nemo-text-processing` to `text-processing-rs` to remove NeMo branding
- Update description, keywords, Rust imports, doc examples, build scripts, and linker references
- FFI symbol names (`nemo_normalize`, etc.) unchanged to preserve ABI compatibility

Closes #2

## Verification
- `cargo build` passes
- `cargo test` passes (143 tests: 83 unit + 57 integration + 3 doc)
- `cargo publish --dry-run` passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/text-processing-rs/pull/3" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
