### PR TITLE
chore: add CLAUDE.md with project conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+# CLAUDE.md
+
+## Git Operations
+
+- Never run `git push` unless explicitly requested
+- No Co-Author tags: Do not add `Co-Authored-By` lines for Claude, Copilot, or any AI assistant in commit messages
+
+## Build Commands
+
+```bash
+cargo build
+cargo test
+cargo fmt
+cargo build --features ffi
+```
+
+## Project Structure
+
+- `src/asr/` - ITN taggers (spoken to written, for ASR/STT post-processing)
+- `src/tts/` - TN taggers (written to spoken, for TTS preprocessing)
+- `src/custom_rules.rs` - User-defined custom normalization rules
+- `src/ffi.rs` - C FFI bindings for Swift/Python integration
+- `tests/` - Integration and extensive edge-case tests


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` with project conventions (no AI co-author tags in commits, build commands, project structure reference)

## Test plan
- [ ] No code changes, documentation only
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/text-processing-rs/pull/5" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
