### PR TITLE
fix: currency trailing dot panic and measure parser premature exit

### DIFF
--- a/src/tts/measure.rs
+++ b/src/tts/measure.rs
@@ -152,7 +152,14 @@ pub fn parse(input: &str) -> Option<String> {
         if clean.contains('.') {
             let parts: Vec<&str> = clean.splitn(2, '.').collect();
             if parts.len() == 2 {
-                let int_val: i64 = parts[0].parse().ok()?;
+                let int_val: i64 = if parts[0].is_empty() {
+                    0
+                } else {
+                    let Ok(v) = parts[0].parse::<i64>() else {
+                        continue;
+                    };
+                    v
+                };
                 let int_words = number_to_words(int_val);
                 let frac_words = super::spell_digits(parts[1]);
                 let unit_word = unit_info.plural; // decimals are usually plural
@@ -166,7 +173,9 @@ pub fn parse(input: &str) -> Option<String> {
             continue;
         }
 
-        let n: i64 = clean.parse().ok()?;
+        let Ok(n) = clean.parse::<i64>() else {
+            continue;
+        };
         let num_words = if is_negative {
             format!("minus {}", number_to_words(n))
         } else {
@@ -230,6 +239,15 @@ mod tests {
     fn test_data() {
         assert_eq!(parse("500 MB"), Some("five hundred megabytes".to_string()));
         assert_eq!(parse("1 GB"), Some("one gigabyte".to_string()));
+    }
+
+    #[test]
+    fn test_decimal_with_empty_integer() {
+        // ".5 kg" should not cause premature return — continue to next unit
+        assert_eq!(
+            parse(".5 kg"),
+            Some("zero point five kilograms".to_string())
+        );
     }
 
     #[test]

--- a/src/tts/money.rs
+++ b/src/tts/money.rs
@@ -148,7 +148,9 @@ fn parse_dollars_cents(amount: &str, currency: &Currency) -> Option<String> {
     let cents_str = parts[1];
 
     // Pad or truncate cents to 2 digits
-    let cents: i64 = if cents_str.len() == 1 {
+    let cents: i64 = if cents_str.is_empty() {
+        0
+    } else if cents_str.len() == 1 {
         cents_str.parse::<i64>().ok()? * 10
     } else if cents_str.len() == 2 {
         cents_str.parse().ok()?
@@ -256,6 +258,14 @@ mod tests {
         assert_eq!(parse("€100"), Some("one hundred euros".to_string()));
         assert_eq!(parse("£1"), Some("one pound".to_string()));
         assert_eq!(parse("¥500"), Some("five hundred yen".to_string()));
+    }
+
+    #[test]
+    fn test_trailing_dot() {
+        // "$5." should not panic — empty cents treated as zero
+        assert_eq!(parse("$5."), Some("five dollars".to_string()));
+        assert_eq!(parse("$1."), Some("one dollar".to_string()));
+        assert_eq!(parse("$0."), Some("zero dollars".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- **money.rs**: Handle empty cents string when input ends with a trailing dot (e.g. `"$5."`). Previously panicked with index-out-of-bounds when `cents_str` was empty.
- **measure.rs**: Replace `?` operators with `continue` in the unit-matching loop so a failed number parse tries the next unit candidate instead of aborting the entire function. Also handle empty integer part in decimals (e.g. `".5 kg"` → `"zero point five kilograms"`).

Fixes issues flagged in https://github.com/FluidInference/text-processing-rs/pull/4#pullrequestreview-3935446045

## Test plan
- [x] Added unit test for `"$5."`, `"$1."`, `"$0."` trailing dot cases
- [x] Added unit test for `".5 kg"` empty integer decimal case
- [x] All 362 existing tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/text-processing-rs/pull/6" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
