### PR TITLE
docs(readme): fix Rust imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Converts written-form text to spoken form (useful for TTS preprocessing):
 ### Rust
 
 ```rust
-use nemo_text_processing::{normalize, tn_normalize};
+use text_processing_rs::{normalize, tn_normalize};
 
 // ITN: spoken → written
 let result = normalize("two hundred");
@@ -111,7 +111,7 @@ await init();
 Sentence-level normalization scans for normalizable spans within a larger sentence:
 
 ```rust
-use nemo_text_processing::{normalize_sentence, tn_normalize_sentence};
+use text_processing_rs::{normalize_sentence, tn_normalize_sentence};
 
 // ITN sentence mode
 let result = normalize_sentence("I have twenty one apples");


### PR DESCRIPTION
I think `text_processing_rs` is correct usage.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/text-processing-rs/pull/17" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
