### PR TITLE
chore: bump version to 0.2.0 (fixes #16)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "text-processing-rs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "console_error_panic_hook",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "text-processing-rs"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Inverse Text Normalization (ITN) — convert spoken-form ASR output to written form"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidinference/text-processing-rs",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Inverse Text Normalization (ITN) — convert spoken-form ASR output to written form",
   "type": "module",
   "main": "pkg-web/text_processing_rs.js",

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -168,7 +168,7 @@ pub extern "C" fn nemo_rule_count() -> u32 {
 /// Returns a static string, do not free.
 #[no_mangle]
 pub extern "C" fn nemo_version() -> *const c_char {
-    static VERSION: &[u8] = b"0.1.0\0";
+    static VERSION: &[u8] = concat!(env!("CARGO_PKG_VERSION"), "\0").as_bytes();
     VERSION.as_ptr() as *const c_char
 }
 


### PR DESCRIPTION
## Summary
Closes #16 — `tn_normalize_sentence` (and a lot of other public API) is missing from the published crate because crates.io still has **0.1.0**, which was cut from commit `699a68c` (2026-03-07).

Since then, ~49 commits of feature work have landed on `main` without a release, including:
- `pub fn tn_normalize_sentence` + full TN (written → spoken) support
- Multi-language ITN for FR, DE, ES, HI, JA, ZH
- Module rename from `asr/tts` to `itn/tn`
- JavaScript-callable wasm bindings

Users running `cargo add text-processing-rs` and trying to import `tn_normalize_sentence` hit `unresolved import` because that function only exists post-0.1.0.

## Changes
- Bump `Cargo.toml` from `0.1.0` → `0.2.0`
- Bump `Cargo.lock` to match
- Bump `package.json` (npm wasm package) to match

Picking `0.2.0` over `0.1.1` because the breadth of new public surface (multi-language ITN, full TN API, wasm bindings) is well beyond a patch-level change.

## Follow-up needed
After merge, a maintainer needs to:
- [ ] Tag `v0.2.0`
- [ ] `cargo publish`
- [ ] Optionally `npm publish` the wasm package

## Test plan
- [ ] CI passes
- [ ] Reproduce reporter's snippet against `main`:
  ```rust
  use text_processing_rs::tn_normalize_sentence;
  fn main() { println!("{}", tn_normalize_sentence("I have twenty one apples.")); }
  ```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/text-processing-rs/pull/19" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
