### PR TITLE
fix(ci): pass --features to cargo via -- separator in wasm-pack

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "pkg-web/text_processing_rs_bg.wasm.d.ts"
   ],
   "scripts": {
-    "wasm:build:node": "wasm-pack build --release --target nodejs --features wasm && mkdir -p pkg-node && cp -f pkg/* pkg-node/ && node scripts/set-wasm-package-name.mjs pkg-node",
-    "wasm:build:web": "wasm-pack build --release --target web --features wasm && mkdir -p pkg-web && cp -f pkg/* pkg-web/ && node scripts/set-wasm-package-name.mjs pkg-web",
+    "wasm:build:node": "wasm-pack build --release --target nodejs -- --features wasm && mkdir -p pkg-node && cp -f pkg/* pkg-node/ && node scripts/set-wasm-package-name.mjs pkg-node",
+    "wasm:build:web": "wasm-pack build --release --target web -- --features wasm && mkdir -p pkg-web && cp -f pkg/* pkg-web/ && node scripts/set-wasm-package-name.mjs pkg-web",
     "wasm:test:node": "node wasm-tests/node-smoke.mjs",
     "wasm:ci": "npm run wasm:build:node && npm run wasm:test:node && npm run wasm:build:web",
     "wasm:pack": "npm pack ./pkg-web",


### PR DESCRIPTION
## Summary
- Fixes WASM CI job failure: `error: Found argument '--features' which wasn't expected, or isn't valid in this context`
- `wasm-pack build` does not accept `--features` directly; cargo arguments must come after the `--` separator

## Context
Failing job: https://github.com/FluidInference/text-processing-rs/actions/runs/24977493447/job/73132168878

Before:
```
wasm-pack build --release --target nodejs --features wasm
```

After:
```
wasm-pack build --release --target nodejs -- --features wasm
```

## Test plan
- [ ] CI WASM job passes
- [ ] `npm run wasm:build:node` succeeds locally
- [ ] `npm run wasm:build:web` succeeds locally
- [ ] `npm run wasm:ci` succeeds locally
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/text-processing-rs/pull/27" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
