### PR TITLE
chore(release): v0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "text-processing-rs"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "console_error_panic_hook",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "text-processing-rs"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "Inverse Text Normalization (ITN) — convert spoken-form ASR output to written form"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidinference/text-processing-rs",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Inverse Text Normalization (ITN) — convert spoken-form ASR output to written form",
   "type": "module",
   "main": "pkg-web/text_processing_rs.js",


### PR DESCRIPTION
## Summary
Release v0.2.2 — bug fixes and CI improvements.

## Changes since v0.2.1
- feat: unified `NormalizeOptions` API + fix #23 compound concat (#24)
- fix: split trailing punctuation in sentence mode (#21) (#25)
- fix: add `disable_bare_second` flag (#22) + restore TN abbreviation matching (#26)
- fix(ci): pass `--features` to cargo via `--` separator in wasm-pack (#27)

## Test plan
- [x] `cargo build` succeeds
- [ ] `cargo test` passes
- [ ] WASM CI passes
- [ ] Tag `v0.2.2` after merge
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/text-processing-rs/pull/28" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
