### PR TITLE
feat(itn/fr): French fraction tagger — sync NeMo test data

### DIFF
--- a/src/itn/fr/fraction.rs
+++ b/src/itn/fr/fraction.rs
@@ -1,0 +1,147 @@
+//! Fraction tagger for French.
+//!
+//! Converts spoken French fractions to written form:
+//! - "un tiers" → "1/3"
+//! - "deux neuvièmes" → "2/9"
+//! - "un et demi" → "1 1/2" (mixed)
+//! - "quatre et deux quatrièmes" → "4 2/4" (mixed)
+
+use super::cardinal;
+
+/// Parse a spoken French fraction to written form.
+pub fn parse(input: &str) -> Option<String> {
+    let lower = input.to_lowercase();
+    let trimmed = lower.trim();
+
+    // Mixed fraction: "WHOLE et FRACTION" → "WHOLE N/D"
+    // ("un et demi" → "1 1/2", "quatre et deux quatrièmes" → "4 2/4").
+    if let Some(pos) = trimmed.find(" et ") {
+        let whole_part = &trimmed[..pos];
+        let frac_part = &trimmed[pos + " et ".len()..];
+        if let (Some(whole), Some(frac)) =
+            (word_to_int(whole_part), parse_simple_fraction(frac_part))
+        {
+            return Some(format!("{} {}", whole, frac));
+        }
+    }
+
+    parse_simple_fraction(trimmed)
+}
+
+/// Parse a simple fraction: "deux neuvièmes" → "2/9", bare "demi" → "1/2".
+fn parse_simple_fraction(input: &str) -> Option<String> {
+    let trimmed = input.trim();
+
+    // Bare "demi" carries an implicit numerator of one.
+    if trimmed == "demi" {
+        return Some("1/2".to_string());
+    }
+
+    let tokens: Vec<&str> = trimmed.split_whitespace().collect();
+    if tokens.len() < 2 {
+        return None;
+    }
+
+    let denom = parse_denominator(tokens.last()?)?;
+    let numer = word_to_int(&tokens[..tokens.len() - 1].join(" "))?;
+    Some(format!("{}/{}", numer, denom))
+}
+
+/// French number word → integer, treating bare `un`/`une` as one (the
+/// cardinal tagger expects a fuller phrase).
+fn word_to_int(input: &str) -> Option<i128> {
+    let trimmed = input.trim();
+    if trimmed == "un" || trimmed == "une" {
+        return Some(1);
+    }
+    cardinal::words_to_number(trimmed)
+}
+
+/// French ordinal (or `demi`/`tiers`/`quart`) denominator word → integer.
+/// Accepts the plural `-s` form (`neuvièmes`).
+fn parse_denominator(word: &str) -> Option<i128> {
+    match word {
+        "demi" | "demis" => return Some(2),
+        "tiers" => return Some(3),
+        "quart" | "quarts" => return Some(4),
+        _ => {}
+    }
+
+    // Ordinal `-ième(s)` forms; drop the plural `s` first.
+    let singular = word.strip_suffix('s').unwrap_or(word);
+    let value = match singular {
+        "quatrième" => 4,
+        "cinquième" => 5,
+        "sixième" => 6,
+        "septième" => 7,
+        "huitième" => 8,
+        "neuvième" => 9,
+        "dixième" => 10,
+        "onzième" => 11,
+        "douzième" => 12,
+        "treizième" => 13,
+        "quatorzième" => 14,
+        "quinzième" => 15,
+        "seizième" => 16,
+        "dix-septième" => 17,
+        "dix-huitième" => 18,
+        "dix-neuvième" => 19,
+        "vingtième" => 20,
+        "trentième" => 30,
+        "quarantième" => 40,
+        "cinquantième" => 50,
+        "soixantième" => 60,
+        "soixante-dixième" => 70,
+        "quatre-vingtième" => 80,
+        "quatre-vingt-dixième" => 90,
+        "centième" => 100,
+        _ => return None,
+    };
+    Some(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_simple() {
+        assert_eq!(parse("un tiers"), Some("1/3".to_string()));
+        assert_eq!(parse("un quart"), Some("1/4".to_string()));
+        assert_eq!(parse("un cinquième"), Some("1/5".to_string()));
+        assert_eq!(parse("un quatrième"), Some("1/4".to_string()));
+        assert_eq!(parse("un centième"), Some("1/100".to_string()));
+    }
+
+    #[test]
+    fn test_bare_demi() {
+        assert_eq!(parse("demi"), Some("1/2".to_string()));
+    }
+
+    #[test]
+    fn test_plural_denominator() {
+        assert_eq!(parse("deux neuvièmes"), Some("2/9".to_string()));
+    }
+
+    #[test]
+    fn test_compound_denominator() {
+        assert_eq!(parse("un dix-septième"), Some("1/17".to_string()));
+        assert_eq!(parse("un soixante-dixième"), Some("1/70".to_string()));
+        assert_eq!(parse("un quatre-vingt-dixième"), Some("1/90".to_string()));
+    }
+
+    #[test]
+    fn test_mixed() {
+        assert_eq!(parse("un et demi"), Some("1 1/2".to_string()));
+        assert_eq!(
+            parse("quatre et deux quatrièmes"),
+            Some("4 2/4".to_string())
+        );
+    }
+
+    #[test]
+    fn test_not_a_fraction() {
+        assert_eq!(parse("bonjour"), None);
+        assert_eq!(parse("cinq"), None);
+    }
+}

--- a/src/itn/fr/mod.rs
+++ b/src/itn/fr/mod.rs
@@ -9,6 +9,7 @@ pub mod cardinal;
 pub mod date;
 pub mod decimal;
 pub mod electronic;
+pub mod fraction;
 pub mod measure;
 pub mod money;
 pub mod ordinal;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,6 +268,12 @@ fn try_fr_taggers(input: &str) -> Option<String> {
     if let Some(result) = itn::fr::electronic::parse(input) {
         return Some(result);
     }
+    // Fraction before ordinal: `un cinquième` is a fraction (1/5), but the
+    // ordinal tagger would otherwise greedily read the `-ième` word. Bare
+    // ordinals (`cinquième`) return None from fraction and fall through.
+    if let Some(result) = itn::fr::fraction::parse(input) {
+        return Some(result);
+    }
     if let Some(result) = itn::fr::ordinal::parse(input) {
         return Some(result);
     }

--- a/tests/data/fr/fraction.txt
+++ b/tests/data/fr/fraction.txt
@@ -1,0 +1,30 @@
+demi~1/2
+un tiers~1/3
+un quart~1/4
+un cinquième~1/5
+un sixième~1/6
+un septième~1/7
+un huitième~1/8
+deux neuvièmes~2/9
+un et demi~1 1/2
+un dixième~1/10
+un onzième~1/11
+un douzième~1/12
+un treizième~1/13
+un quatrième~1/4
+un quatorzième~1/14
+un quinzième~1/15
+un seizième~1/16
+un dix-septième~1/17
+un dix-huitième~1/18
+un dix-neuvième~1/19
+un vingtième~1/20
+un trentième~1/30
+un quarantième~1/40
+un cinquantième~1/50
+un soixantième~1/60
+un soixante-dixième~1/70
+un quatre-vingtième~1/80
+un quatre-vingt-dixième~1/90
+un centième~1/100
+quatre et deux quatrièmes~4 2/4

--- a/tests/fr_tests.rs
+++ b/tests/fr_tests.rs
@@ -152,3 +152,20 @@ fn test_word() {
     );
     print_failures(&results);
 }
+
+#[test]
+fn test_fraction() {
+    let results = common::run_test_file(Path::new("tests/data/fr/fraction.txt"), normalize_fr);
+    println!(
+        "fraction: {}/{} passed ({} failures)",
+        results.passed,
+        results.total,
+        results.failures.len()
+    );
+    print_failures(&results);
+    assert!(
+        results.failures.is_empty(),
+        "{} fraction ITN tests failed",
+        results.failures.len()
+    );
+}


### PR DESCRIPTION
## Context: NeMo sync audit

Compared the vendored `tests/data/**` against a fresh clone of upstream **NVIDIA/NeMo-text-processing** across all 7 supported languages (en, de, es, fr, hi, ja, zh), both ITN and TN. Result: **the only ITN drift is a French `fraction` class** (29 cases) that upstream added and the port never vendored. Every other class in every supported language is already byte-identical to current upstream, and the port passes 100% of the latest upstream ITN cases.

## Change

Adds `itn::fr::fraction` (French was the only supported language missing a fraction tagger — de/es/hi/ja/zh already have one):

| Input | Output |
|-------|--------|
| `un tiers` | `1/3` |
| `un quart` | `1/4` |
| `deux neuvièmes` | `2/9` |
| `un dix-septième` | `1/17` |
| `un quatre-vingt-dixième` | `1/90` |
| `demi` | `1/2` |
| `un et demi` (mixed) | `1 1/2` |
| `quatre et deux quatrièmes` (mixed) | `4 2/4` |

- Denominator words map French ordinals (`cinquième`→5 … `centième`→100, plural `-s` accepted) plus the irregular `demi`/`tiers`/`quart`.
- Numerators / whole parts reuse `fr::cardinal::words_to_number` (with bare `un`/`une` → 1).
- Registered **before** the ordinal tagger so `un cinquième` reads as `1/5`; bare ordinals (`cinquième`, single token) return `None` and fall through to `ordinal` — no ordinal regression.

## Tests
- Vendors the 29 upstream cases as `tests/data/fr/fraction.txt`.
- Adds `test_fraction` that **asserts 100%** (the other FR suites only print — this one locks the class in).
- Unit tests for simple / bare-demi / plural / compound / mixed / negative-path.
- Full suite green (730+ lib + all integration suites, 0 failures). `cargo fmt --check` clean; new file has 0 clippy warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)