### PR TITLE
feat(tn/en): English fraction tagger — close TN fraction gap

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1246,6 +1246,9 @@ pub fn tn_normalize(input: &str) -> String {
     if let Some(result) = tn::en::time::parse(input) {
         return result;
     }
+    if let Some(result) = tn::en::fraction::parse(input) {
+        return result;
+    }
     if let Some(result) = tn::en::electronic::parse(input) {
         return result;
     }
@@ -1287,6 +1290,9 @@ fn tn_parse_span(span: &str) -> Option<(String, u8)> {
     }
     if let Some(result) = tn::en::time::parse(span) {
         return Some((result, 85));
+    }
+    if let Some(result) = tn::en::fraction::parse(span) {
+        return Some((result, 81));
     }
     if let Some(result) = tn::en::electronic::parse(span) {
         return Some((result, 82));

--- a/src/tn/en/fraction.rs
+++ b/src/tn/en/fraction.rs
@@ -1,0 +1,167 @@
+//! Fraction TN tagger.
+//!
+//! Converts written fractions to spoken form:
+//! - "1/2" → "one half"
+//! - "3/4" → "three quarters"
+//! - "31/32" → "thirty one thirty seconds"
+//! - "3 2/4" → "three and two quarters" (mixed)
+//! - "2 1/2" → "two and a half" (mixed)
+//! - "142/1" → "one hundred forty two over one"
+
+use super::number_to_words;
+use super::ordinal::number_to_ordinal_words;
+
+/// Parse a written fraction to spoken form.
+pub fn parse(input: &str) -> Option<String> {
+    let trimmed = input.trim();
+    if !trimmed.contains('/') {
+        return None;
+    }
+
+    // Collapse spaces immediately around the slash ("1795 / 1805" →
+    // "1795/1805") so only a mixed fraction's whole/numerator gap remains as
+    // a space.
+    let collapsed = trimmed.replace(" /", "/").replace("/ ", "/");
+
+    // Mixed fraction: "WHOLE NUMER/DENOM" (a space now separates the whole
+    // number from the fraction, e.g. "3 2/4").
+    if let Some((whole_str, frac_str)) = collapsed.split_once(' ') {
+        let whole: i64 = whole_str.trim().parse().ok()?;
+        let frac = parse_simple(frac_str.trim(), true)?;
+        return Some(format!("{} and {}", number_to_words(whole), frac));
+    }
+
+    parse_simple(&collapsed, false)
+}
+
+/// Parse `NUMER/DENOM` (denominator may carry a written ordinal suffix like
+/// `4th`). `mixed` selects the "a half" rendering used only after a whole
+/// number ("2 1/2" → "two and a half", but standalone "1/2" → "one half").
+fn parse_simple(input: &str, mixed: bool) -> Option<String> {
+    let (numer_str, denom_raw) = input.split_once('/')?;
+    let numer: i64 = numer_str.trim().parse().ok()?;
+
+    // Drop a trailing ordinal suffix on the denominator (`4th`, `3RD`).
+    let denom_trim = denom_raw.trim();
+    let denom_digits = strip_ordinal_suffix(denom_trim);
+    let denom: i64 = denom_digits.parse().ok()?;
+
+    let plural = numer != 1;
+
+    // Denominator of one reads as "over one" rather than an ordinal.
+    if denom == 1 {
+        return Some(format!("{} over one", number_to_words(numer)));
+    }
+
+    if mixed && numer == 1 && denom == 2 {
+        return Some("a half".to_string());
+    }
+
+    let denom_word = denominator_words(denom, plural);
+    Some(format!("{} {}", number_to_words(numer), denom_word))
+}
+
+/// Strip a trailing case-insensitive ordinal suffix (`st`/`nd`/`rd`/`th`),
+/// leaving just the digits.
+fn strip_ordinal_suffix(denom: &str) -> &str {
+    for suffix in ["st", "nd", "rd", "th"] {
+        if denom.len() > suffix.len() {
+            let (head, tail) = denom.split_at(denom.len() - suffix.len());
+            if tail.eq_ignore_ascii_case(suffix) && head.bytes().all(|b| b.is_ascii_digit()) {
+                return head;
+            }
+        }
+    }
+    denom
+}
+
+/// The spoken denominator word: irregular half/third/quarter, otherwise the
+/// ordinal reading. Pluralized (`quarters`, `thirty seconds`) when `plural`.
+fn denominator_words(denom: i64, plural: bool) -> String {
+    let (singular, plural_form) = match denom {
+        2 => ("half", "halves"),
+        3 => ("third", "thirds"),
+        4 => ("quarter", "quarters"),
+        _ => {
+            let ordinal = number_to_ordinal_words(denom);
+            return if plural {
+                format!("{}s", ordinal)
+            } else {
+                ordinal
+            };
+        }
+    };
+    if plural { plural_form } else { singular }.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_simple() {
+        assert_eq!(parse("1/2"), Some("one half".to_string()));
+        assert_eq!(parse("1/3"), Some("one third".to_string()));
+        assert_eq!(parse("1/4"), Some("one quarter".to_string()));
+        assert_eq!(parse("22/3"), Some("twenty two thirds".to_string()));
+        assert_eq!(
+            parse("31/32"),
+            Some("thirty one thirty seconds".to_string())
+        );
+    }
+
+    #[test]
+    fn test_ordinal_suffix_on_denominator() {
+        assert_eq!(parse("1/4th"), Some("one quarter".to_string()));
+        assert_eq!(parse("2/4TH"), Some("two quarters".to_string()));
+        assert_eq!(parse("1/3RD"), Some("one third".to_string()));
+    }
+
+    #[test]
+    fn test_large_denominators() {
+        assert_eq!(
+            parse("1/2007"),
+            Some("one two thousand seventh".to_string())
+        );
+        assert_eq!(
+            parse("12639/12640"),
+            Some(
+                "twelve thousand six hundred thirty nine twelve thousand six hundred fortieths"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_mixed() {
+        assert_eq!(parse("3 2/4"), Some("three and two quarters".to_string()));
+        assert_eq!(parse("2 1/2"), Some("two and a half".to_string()));
+        assert_eq!(parse("3 5/2"), Some("three and five halves".to_string()));
+    }
+
+    #[test]
+    fn test_over_one() {
+        assert_eq!(
+            parse("2 142/1"),
+            Some("two and one hundred forty two over one".to_string())
+        );
+    }
+
+    #[test]
+    fn test_spaced_slash() {
+        assert_eq!(
+            parse("1795 / 1805"),
+            Some(
+                "one thousand seven hundred ninety five one thousand eight hundred fifths"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_not_a_fraction() {
+        assert_eq!(parse("hello"), None);
+        assert_eq!(parse("12"), None);
+        assert_eq!(parse("1/2/3"), None);
+    }
+}

--- a/src/tn/en/mod.rs
+++ b/src/tn/en/mod.rs
@@ -9,6 +9,7 @@ pub mod cardinal;
 pub mod date;
 pub mod decimal;
 pub mod electronic;
+pub mod fraction;
 pub mod measure;
 pub mod money;
 pub mod ordinal;

--- a/src/tn/en/ordinal.rs
+++ b/src/tn/en/ordinal.rs
@@ -39,6 +39,12 @@ pub fn parse(input: &str) -> Option<String> {
     Some(cardinal_to_ordinal(&cardinal))
 }
 
+/// Spell an integer as ordinal words (`2640` → "two thousand six hundred
+/// fortieth"). Shared with the fraction tagger for denominators.
+pub(crate) fn number_to_ordinal_words(n: i64) -> String {
+    cardinal_to_ordinal(&number_to_words(n))
+}
+
 /// Convert cardinal words to ordinal words by replacing the last word.
 ///
 /// "twenty one" → "twenty first"

--- a/tests/data/en/tn_fraction.txt
+++ b/tests/data/en/tn_fraction.txt
@@ -1,0 +1,16 @@
+1/2007~one two thousand seventh
+12639/12640~twelve thousand six hundred thirty nine twelve thousand six hundred fortieths
+3 2/4~three and two quarters
+1/4~one quarter
+1/4th~one quarter
+2/4th~two quarters
+1/4TH~one quarter
+1/3RD~one third
+31/32~thirty one thirty seconds
+22/3~twenty two thirds
+1/3~one third
+2 142/1~two and one hundred forty two over one
+1/2~one half
+2 1/2~two and a half
+3 5/2~three and five halves
+1795 / 1805~one thousand seven hundred ninety five one thousand eight hundred fifths

--- a/tests/en_tn_tests.rs
+++ b/tests/en_tn_tests.rs
@@ -261,3 +261,20 @@ fn test_pr25_tn_abbreviation_regression() {
     );
     assert_eq!(tn_normalize_sentence("Prof. Jones"), "professor Jones");
 }
+
+#[test]
+fn test_tn_fraction() {
+    let results = common::run_test_file(Path::new("tests/data/en/tn_fraction.txt"), tn_normalize);
+    println!(
+        "tn_fraction: {}/{} passed ({} failures)",
+        results.passed,
+        results.total,
+        results.failures.len()
+    );
+    print_failures(&results);
+    assert!(
+        results.failures.is_empty(),
+        "{} fraction TN tests failed",
+        results.failures.len()
+    );
+}


### PR DESCRIPTION
## TN-gap installment 1: fractions

Part of closing the English **TN** (written→spoken) gaps vs NeMo. Written fractions previously passed through unchanged — **0/16** upstream NeMo cases. This adds `tn::en::fraction`, passing **all** of them.

| Input | Output |
|-------|--------|
| `1/2` | one half |
| `3/4` | three quarters |
| `1/3` | one third |
| `31/32` | thirty one thirty seconds |
| `22/3` | twenty two thirds |
| `1/2007` | one two thousand seventh |
| `12639/12640` | twelve thousand six hundred thirty nine twelve thousand six hundred fortieths |
| `1/4th`, `1/3RD` | one quarter / one third (ordinal suffix stripped) |
| `3 2/4` | three and two quarters (mixed) |
| `2 1/2` | two and a half (mixed special) |
| `2 142/1` | two and one hundred forty two over one |
| `1795 / 1805` | one thousand seven hundred ninety five one thousand eight hundred fifths |

### Rules
- Numerator = cardinal; denominator = irregular half/third/quarter, otherwise the ordinal reading, pluralized when the numerator ≠ 1.
- Mixed `W N/D` → `<whole> and <fraction>`, with the `1/2`-after-whole special (`a half`). `N/1` → `… over one`.
- Handles a trailing ordinal suffix on the denominator and spaces around the slash.
- Denominators reuse a new `tn::en::ordinal::number_to_ordinal_words` helper.

### Dispatch / safety
Wired into both the single-expression and sentence-mode TN dispatch **after `time`, before `electronic`** (priority 81). `1/5/2025` still resolves as a date (3-part, date runs earlier); measures like `12/kg` still resolve via `measure`. Full suite green (no regressions).

### Tests
Vendors the 15 upstream NeMo cases as `tests/data/en/tn_fraction.txt` with an **asserting** `test_tn_fraction`, plus unit coverage (proper / suffix / large denominators / mixed / over-one / spaced-slash / negatives). `cargo fmt --check` clean; new file 0 clippy warnings.

## Remaining TN gaps (tracked, follow-ups)
`math`, `roman`, `range`, `serial`, a broken `time` (`01:00` → "one"), and refinements to `electronic`/`measure`/`money`. The `cardinal` "British *and*" differences are **intentional style** (American), not gaps, and won't be chased since the port feeds FluidAudio TTS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)