### PR TITLE
feat(tn/en): NeMo cardinal conventions — British "and" + digit-string rule

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1336,7 +1336,7 @@ pub fn tn_normalize_sentence(input: &str) -> String {
 /// use text_processing_rs::tn_normalize_lang;
 ///
 /// assert_eq!(tn_normalize_lang("123", "fr"), "cent vingt-trois");
-/// assert_eq!(tn_normalize_lang("123", "en"), "one hundred twenty three");
+/// assert_eq!(tn_normalize_lang("123", "en"), "one hundred and twenty three");
 /// ```
 pub fn tn_normalize_lang(input: &str, lang: &str) -> String {
     tn_normalize_for_lang(input, lang)
@@ -1467,7 +1467,7 @@ mod tests {
 
     #[test]
     fn test_tn_cardinal() {
-        assert_eq!(tn_normalize("123"), "one hundred twenty three");
+        assert_eq!(tn_normalize("123"), "one hundred and twenty three");
         assert_eq!(tn_normalize("0"), "zero");
         assert_eq!(tn_normalize("1000"), "one thousand");
     }

--- a/src/tn/en/cardinal.rs
+++ b/src/tn/en/cardinal.rs
@@ -1,16 +1,19 @@
 //! Cardinal TN tagger.
 //!
-//! Converts written cardinal numbers to spoken form:
-//! - "123" → "one hundred twenty three"
+//! Converts written cardinal numbers to spoken form (NeMo conventions):
+//! - "123" → "one hundred and twenty three" (British "and")
 //! - "-42" → "minus forty two"
 //! - "1,000" → "one thousand"
-//! - "0" → "zero"
+//! - "13000" → "one three zero zero zero" (unformatted >4 digits → digits)
+//! - "004" → "zero zero four" (leading zero → digits)
 
-use super::number_to_words;
+use super::{number_to_words_and, spell_digits};
 
 /// Parse a written cardinal number to spoken words.
 ///
-/// Detects pure digit strings with optional leading minus and commas.
+/// Pure digit strings with an optional leading minus and comma grouping.
+/// An *unformatted* (comma-less) integer that is longer than four digits or
+/// carries a leading zero is read digit-by-digit, matching NeMo.
 pub fn parse(input: &str) -> Option<String> {
     let trimmed = input.trim();
     if trimmed.is_empty() {
@@ -23,24 +26,32 @@ pub fn parse(input: &str) -> Option<String> {
         (false, trimmed)
     };
 
-    // Must be digits (with optional commas)
+    // Must be digits (with optional commas), and contain at least one digit.
     if !digits_part.chars().all(|c| c.is_ascii_digit() || c == ',') {
         return None;
     }
-
-    // Must contain at least one digit
     if !digits_part.chars().any(|c| c.is_ascii_digit()) {
         return None;
     }
 
-    // Strip commas and parse
+    let has_comma = digits_part.contains(',');
     let clean: String = digits_part.chars().filter(|c| *c != ',').collect();
-    let n: i64 = clean.parse().ok()?;
+
+    // Digit-string rule: an unformatted, non-negative integer that is longer
+    // than four digits or has a leading zero reads digit-by-digit.
+    if !is_negative && !has_comma {
+        let leading_zero = clean.len() > 1 && clean.starts_with('0');
+        if leading_zero || clean.len() > 4 {
+            return Some(spell_digits(&clean));
+        }
+    }
+
+    let n: u128 = clean.parse().ok()?;
 
     if is_negative {
-        Some(format!("minus {}", number_to_words(n)))
+        Some(format!("minus {}", number_to_words_and(n)))
     } else {
-        Some(number_to_words(n))
+        Some(number_to_words_and(n))
     }
 }
 
@@ -54,13 +65,48 @@ mod tests {
         assert_eq!(parse("1"), Some("one".to_string()));
         assert_eq!(parse("21"), Some("twenty one".to_string()));
         assert_eq!(parse("100"), Some("one hundred".to_string()));
-        assert_eq!(parse("123"), Some("one hundred twenty three".to_string()));
+        assert_eq!(
+            parse("123"),
+            Some("one hundred and twenty three".to_string())
+        );
+    }
+
+    #[test]
+    fn test_and_only_in_units_group() {
+        assert_eq!(parse("9000"), Some("nine thousand".to_string()));
+        assert_eq!(
+            parse("123,000"),
+            Some("one hundred twenty three thousand".to_string())
+        );
+        assert_eq!(
+            parse("123,000,012"),
+            Some("one hundred twenty three million twelve".to_string())
+        );
+    }
+
+    #[test]
+    fn test_digit_string() {
+        assert_eq!(parse("13000"), Some("one three zero zero zero".to_string()));
+        assert_eq!(
+            parse("123000"),
+            Some("one two three zero zero zero".to_string())
+        );
+        assert_eq!(parse("004"), Some("zero zero four".to_string()));
     }
 
     #[test]
     fn test_commas() {
         assert_eq!(parse("1,000"), Some("one thousand".to_string()));
         assert_eq!(parse("1,000,000"), Some("one million".to_string()));
+        assert_eq!(parse("13,000"), Some("thirteen thousand".to_string()));
+    }
+
+    #[test]
+    fn test_large_u128() {
+        assert_eq!(
+            parse("124,444,234,854,823,834,553"),
+            Some("one hundred twenty four quintillion four hundred forty four quadrillion two hundred thirty four trillion eight hundred fifty four billion eight hundred twenty three million eight hundred thirty four thousand five hundred and fifty three".to_string())
+        );
     }
 
     #[test]

--- a/src/tn/en/mod.rs
+++ b/src/tn/en/mod.rs
@@ -146,6 +146,68 @@ fn chunk_to_words(n: u32) -> String {
     parts.join(" ")
 }
 
+/// Cardinal words with the British "and" before the final sub-hundred group
+/// (`123` → "one hundred and twenty three"), matching NeMo. The "and" appears
+/// only in the units group: `123,000` → "one hundred twenty three thousand"
+/// (no "and"), `123,000,012` → "one hundred twenty three million twelve".
+///
+/// Takes `u128` so long comma-formatted integers (up to ~10^21) still spell
+/// out; callers handle the sign.
+pub fn number_to_words_and(n: u128) -> String {
+    if n == 0 {
+        return "zero".to_string();
+    }
+
+    let scales: &[(u128, &str)] = &[
+        (1_000_000_000_000_000_000, "quintillion"),
+        (1_000_000_000_000_000, "quadrillion"),
+        (1_000_000_000_000, "trillion"),
+        (1_000_000_000, "billion"),
+        (1_000_000, "million"),
+        (1_000, "thousand"),
+    ];
+
+    let mut parts: Vec<String> = Vec::new();
+    let mut remaining = n;
+
+    for &(scale_value, scale_name) in scales {
+        if remaining >= scale_value {
+            let chunk = remaining / scale_value;
+            remaining %= scale_value;
+            parts.push(format!("{} {}", chunk_to_words(chunk as u32), scale_name));
+        }
+    }
+
+    // Only the final (units) group carries the "and".
+    if remaining > 0 {
+        parts.push(chunk_to_words_and(remaining as u32));
+    }
+
+    parts.join(" ")
+}
+
+/// Convert 1..999 to words with the British "and" between the hundreds and a
+/// nonzero sub-hundred remainder ("five hundred and fifty three"). Groups
+/// without hundreds ("twelve") or without a remainder ("nine hundred") get
+/// no "and".
+fn chunk_to_words_and(n: u32) -> String {
+    let hundreds = n / 100;
+    let rest = n % 100;
+    if hundreds > 0 {
+        if rest > 0 {
+            format!(
+                "{} hundred and {}",
+                ONES[hundreds as usize],
+                chunk_to_words(rest)
+            )
+        } else {
+            format!("{} hundred", ONES[hundreds as usize])
+        }
+    } else {
+        chunk_to_words(n)
+    }
+}
+
 /// Spell each digit of a string individually.
 ///
 /// "14" → "one four"

--- a/swift-test/Sources/NemoTest/NemoTest.swift
+++ b/swift-test/Sources/NemoTest/NemoTest.swift
@@ -233,7 +233,7 @@ let tnCardinalTests: [TC] = [
     ("1", "one"),
     ("21", "twenty one"),
     ("100", "one hundred"),
-    ("123", "one hundred twenty three"),
+    ("123", "one hundred and twenty three"),
     ("1000", "one thousand"),
     ("1,000,000", "one million"),
     ("-42", "minus forty two"),

--- a/tests/data/en/tn_cardinal.txt
+++ b/tests/data/en/tn_cardinal.txt
@@ -1,26 +1,20 @@
-# Cardinal TN: written~spoken
-0~zero
+# English cardinal TN cases (NeMo conventions).
+# 978-0 from the upstream file is intentionally omitted: hyphen-joined
+# numbers belong to the range/serial class, not cardinal.
 1~one
-5~five
-10~ten
-11~eleven
-19~nineteen
-20~twenty
-21~twenty one
-42~forty two
-99~ninety nine
-100~one hundred
-101~one hundred one
-123~one hundred twenty three
-999~nine hundred ninety nine
-1000~one thousand
-1001~one thousand one
-1234~one thousand two hundred thirty four
-10000~ten thousand
-100000~one hundred thousand
-1000000~one million
-2000003~two million three
--42~minus forty two
--1000~minus one thousand
-1,000~one thousand
+2~two
+-2~minus two
+3~three
+123~one hundred and twenty three
+13,000~thirteen thousand
+13000~one three zero zero zero
+9000~nine thousand
+9,000~nine thousand
+123,000~one hundred twenty three thousand
+123000~one two three zero zero zero
+123,123,000~one hundred twenty three million one hundred twenty three thousand
+123,000,012~one hundred twenty three million twelve
 1,000,000~one million
+1234567890123124~one two three four five six seven eight nine zero one two three one two four
+004~zero zero four
+124,444,234,854,823,834,553~one hundred twenty four quintillion four hundred forty four quadrillion two hundred thirty four trillion eight hundred fifty four billion eight hundred twenty three million eight hundred thirty four thousand five hundred and fifty three

--- a/tests/extensive_tests.rs
+++ b/tests/extensive_tests.rs
@@ -297,10 +297,13 @@ fn test_tn_cardinal_teens() {
 #[test]
 fn test_tn_cardinal_large() {
     assert_eq!(tn_normalize("1000"), "one thousand");
-    assert_eq!(tn_normalize("1000000"), "one million");
+    // Unformatted integers longer than four digits read digit-by-digit (NeMo).
+    assert_eq!(tn_normalize("1000000"), "one zero zero zero zero zero zero");
+    assert_eq!(tn_normalize("1234567"), "one two three four five six seven");
+    // Comma grouping keeps the word form.
     assert_eq!(
-        tn_normalize("1234567"),
-        "one million two hundred thirty four thousand five hundred sixty seven"
+        tn_normalize("1,234,567"),
+        "one million two hundred thirty four thousand five hundred and sixty seven"
     );
 }
 
@@ -317,7 +320,7 @@ fn test_tn_cardinal_with_commas() {
     assert_eq!(tn_normalize("1,000,000"), "one million");
     assert_eq!(
         tn_normalize("1,234"),
-        "one thousand two hundred thirty four"
+        "one thousand two hundred and thirty four"
     );
 }
 
@@ -1070,7 +1073,7 @@ fn test_roundtrip_cardinal() {
     // Written → Spoken → Written
     let written = "123";
     let spoken = tn_normalize(written);
-    assert_eq!(spoken, "one hundred twenty three");
+    assert_eq!(spoken, "one hundred and twenty three");
     let back_to_written = normalize(&spoken);
     assert_eq!(back_to_written, written);
 }
@@ -1200,7 +1203,7 @@ fn test_boundary_mixed_case() {
 #[test]
 fn test_boundary_leading_trailing_whitespace() {
     assert_eq!(normalize("  twenty one  "), "21");
-    assert_eq!(tn_normalize("  123  "), "one hundred twenty three");
+    assert_eq!(tn_normalize("  123  "), "one hundred and twenty three");
 }
 
 // ════════════════════════════════════════════════════════════════════════
@@ -1237,7 +1240,7 @@ fn test_interference_tn_number_vs_date() {
     // "1980" alone should not be treated as a date by TN
     // It should be treated as a cardinal number
     let result = tn_normalize("1980");
-    assert_eq!(result, "one thousand nine hundred eighty");
+    assert_eq!(result, "one thousand nine hundred and eighty");
 }
 
 #[test]
@@ -1277,7 +1280,7 @@ fn test_itn_decimal_basic() {
 fn test_tts_scenario_address() {
     let result = tn_normalize_sentence("123 Main St");
     assert!(
-        result.contains("one hundred twenty three"),
+        result.contains("one hundred and twenty three"),
         "Address number should be spoken: {}",
         result
     );
@@ -1318,7 +1321,8 @@ fn test_tts_scenario_year_in_sentence() {
     // A year in a sentence should be normalized
     let result = tn_normalize_sentence("Born in 1990");
     assert!(
-        result.contains("one thousand nine hundred ninety") || result.contains("nineteen ninety"),
+        result.contains("one thousand nine hundred and ninety")
+            || result.contains("nineteen ninety"),
         "Year in sentence: {}",
         result
     );

--- a/tests/multilang_tn_tests.rs
+++ b/tests/multilang_tn_tests.rs
@@ -204,7 +204,7 @@ fn test_same_input_different_languages() {
         .map(|lang| (*lang, tn_normalize_lang("123", lang)))
         .collect();
 
-    assert_eq!(results[0].1, "one hundred twenty three"); // en
+    assert_eq!(results[0].1, "one hundred and twenty three"); // en
     assert_eq!(results[1].1, "cent vingt-trois"); // fr
     assert_eq!(results[2].1, "ciento veintitres"); // es
     assert_eq!(results[3].1, "einhundertdreiundzwanzig"); // de
@@ -215,8 +215,11 @@ fn test_same_input_different_languages() {
 
 #[test]
 fn test_unknown_lang_falls_back_to_english() {
-    assert_eq!(tn_normalize_lang("123", "xx"), "one hundred twenty three");
-    assert_eq!(tn_normalize_lang("123", ""), "one hundred twenty three");
+    assert_eq!(
+        tn_normalize_lang("123", "xx"),
+        "one hundred and twenty three"
+    );
+    assert_eq!(tn_normalize_lang("123", ""), "one hundred and twenty three");
 }
 
 #[test]


### PR DESCRIPTION
## TN-gap installment 2: English cardinal (foundational)

Aligns `tn::en::cardinal` with NeMo conventions — the biggest single lever for English/European TN parity, since cardinal spelling underlies money/measure/date/decimal.

### Rule 1 — British "and" (units group only)
"and" is inserted only in the final (10⁰) three-digit group, between the hundreds and a nonzero sub-hundred remainder:

| Input | Output |
|-------|--------|
| `123` | one hundred **and** twenty three |
| `123,000` | one hundred twenty three thousand *(no "and" — 123 isn't the units group)* |
| `123,000,012` | one hundred twenty three million twelve |
| `124,…,553` (21 digits) | … eight hundred thirty four thousand five hundred **and** fifty three |

Implemented via a new `number_to_words_and` (u128, so long comma-formatted integers still spell out). The American `number_to_words` is **untouched**, so other TN classes keep their current output this PR — the "and" propagates class-by-class in later installments.

### Rule 2 — digit-string for unformatted long integers
An *unformatted* (comma-less) integer longer than four digits, or with a leading zero, reads digit-by-digit (NeMo):

| Input | Output |
|-------|--------|
| `13000` | one three zero zero zero |
| `004` | zero zero four |
| `9000` | nine thousand *(≤4 digits → word form)* |
| `13,000` | thirteen thousand *(comma ⇒ word form)* |

### Tests
Re-vendors `tests/data/en/tn_cardinal.txt` from upstream NeMo (omitting the hyphen-joined `978-0`, which is range/serial semantics). Updates the port's own American-style regression expectations. Unit + integration + full suite green; fmt clean; new code clippy-clean.

### ⚠️ Note for TTS consumers (FluidAudio)
Two behavior changes flow downstream: numbers ≥ 100 now say "and", and **bare unformatted `1000000` now reads "one zero zero zero zero zero zero", not "one million".** This is NeMo-exact (this repo is a NeMo port), but it's TTS-relevant — consumers wanting word-form for large numbers should pass comma-grouped input. The digit-string rule is one isolated `if` in `cardinal.rs` if it needs gating downstream. Per the maintainer's "match NeMo exactly" decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)