### PR TITLE
feat(tn/en): complete decimal class to NeMo (leading-dot, integer+scale, magnitude abbrevs)

### DIFF
--- a/src/tn/en/decimal.rs
+++ b/src/tn/en/decimal.rs
@@ -3,11 +3,14 @@
 //! Converts written decimal numbers to spoken form:
 //! - "3.14" → "three point one four"
 //! - "0.5" → "zero point five"
+//! - ".1665" → "point one six six five" (no integer part → no "zero")
 //! - "1.5 billion" → "one point five billion"
+//! - "100 million" → "one hundred million" (integer + scale word)
+//! - "0.1 M" → "zero point one M" (magnitude abbreviation kept literally)
 
 use super::{number_to_words, spell_digits};
 
-/// Scale suffixes we recognize after a decimal number.
+/// Spelled-out scale words recognized after a number.
 const QUANTITY_SUFFIXES: &[&str] = &[
     "billion",
     "million",
@@ -17,34 +20,43 @@ const QUANTITY_SUFFIXES: &[&str] = &[
     "thousand",
 ];
 
-/// Parse a written decimal number to spoken form.
+/// Single-letter magnitude abbreviations kept verbatim after a number
+/// (`0.1 B` → "zero point one B"), matching NeMo. Uppercase only — a
+/// lowercase `m`/`b` is a measurement unit handled by the measure tagger.
+const MAGNITUDE_ABBREVS: &[&str] = &["K", "M", "B", "G", "T"];
+
+/// Parse a written decimal (or integer-with-scale) number to spoken form.
 pub fn parse(input: &str) -> Option<String> {
     let trimmed = input.trim();
     if trimmed.is_empty() {
         return None;
     }
 
-    // Check for quantity suffix: "1.5 billion"
     let (number_part, suffix) = extract_suffix(trimmed);
 
-    // Must contain a decimal point
-    if !number_part.contains('.') {
-        return None;
-    }
-
-    let parts: Vec<&str> = number_part.splitn(2, '.').collect();
-    if parts.len() != 2 {
-        return None;
-    }
-
-    let int_str = parts[0];
-    let frac_str = parts[1];
-
-    // Both parts should be digits (int part may be empty → "0", may have leading minus)
-    let (is_negative, int_digits) = if let Some(rest) = int_str.strip_prefix('-') {
-        (true, rest)
+    let core = if number_part.contains('.') {
+        spell_decimal(number_part)?
     } else {
-        (false, int_str)
+        // A bare integer only belongs to this tagger when it carries a scale
+        // suffix ("100 million"); otherwise it is the cardinal tagger's job.
+        suffix?;
+        spell_integer(number_part)?
+    };
+
+    Some(match suffix {
+        Some(suf) => format!("{} {}", core, suf),
+        None => core,
+    })
+}
+
+/// Spell `[-]INT.FRAC`; an empty integer part omits the leading "zero"
+/// (`.1665` → "point one six six five").
+fn spell_decimal(number_part: &str) -> Option<String> {
+    let (int_str, frac_str) = number_part.split_once('.')?;
+
+    let (is_negative, int_digits) = match int_str.strip_prefix('-') {
+        Some(rest) => (true, rest),
+        None => (false, int_str),
     };
 
     if !int_digits.chars().all(|c| c.is_ascii_digit()) {
@@ -54,36 +66,54 @@ pub fn parse(input: &str) -> Option<String> {
         return None;
     }
 
-    let int_val: i64 = if int_digits.is_empty() {
-        0
-    } else {
-        int_digits.parse().ok()?
-    };
-
-    let int_words = number_to_words(int_val);
     let frac_words = spell_digits(frac_str);
+    let sign = if is_negative { "minus " } else { "" };
 
-    let mut result = if is_negative {
-        format!("minus {} point {}", int_words, frac_words)
+    if int_digits.is_empty() {
+        Some(format!("{}point {}", sign, frac_words))
     } else {
-        format!("{} point {}", int_words, frac_words)
-    };
-
-    if let Some(suf) = suffix {
-        result.push(' ');
-        result.push_str(suf);
+        let int_val: i64 = int_digits.parse().ok()?;
+        Some(format!(
+            "{}{} point {}",
+            sign,
+            number_to_words(int_val),
+            frac_words
+        ))
     }
-
-    Some(result)
 }
 
-/// Extract a quantity suffix from the end if present.
+/// Spell a bare `[-]INT` (used only alongside a scale suffix).
+fn spell_integer(number_part: &str) -> Option<String> {
+    let (is_negative, digits) = match number_part.strip_prefix('-') {
+        Some(rest) => (true, rest),
+        None => (false, number_part),
+    };
+    if digits.is_empty() || !digits.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    let val: i64 = digits.parse().ok()?;
+    let sign = if is_negative { "minus " } else { "" };
+    Some(format!("{}{}", sign, number_to_words(val)))
+}
+
+/// Split off a trailing scale word or magnitude abbreviation.
 fn extract_suffix(input: &str) -> (&str, Option<&str>) {
     for &suf in QUANTITY_SUFFIXES {
         if let Some(before) = input.strip_suffix(suf) {
             let before = before.trim_end();
             if !before.is_empty() {
                 return (before, Some(suf));
+            }
+        }
+    }
+    // Magnitude abbreviations require a space so we never split a bare token.
+    for &suf in MAGNITUDE_ABBREVS {
+        if let Some(before) = input.strip_suffix(suf) {
+            if before.ends_with(' ') {
+                let before = before.trim_end();
+                if !before.is_empty() {
+                    return (before, Some(suf));
+                }
             }
         }
     }
@@ -111,6 +141,29 @@ mod tests {
             parse("4.85 billion"),
             Some("four point eight five billion".to_string())
         );
+    }
+
+    #[test]
+    fn test_leading_dot_omits_zero() {
+        assert_eq!(parse(".1665"), Some("point one six six five".to_string()));
+        assert_eq!(parse(".1 trillion"), Some("point one trillion".to_string()));
+    }
+
+    #[test]
+    fn test_integer_with_scale_word() {
+        assert_eq!(
+            parse("100 million"),
+            Some("one hundred million".to_string())
+        );
+        // A bare integer without a scale word is not this tagger's job.
+        assert_eq!(parse("100"), None);
+    }
+
+    #[test]
+    fn test_magnitude_abbreviation() {
+        assert_eq!(parse("0.1 M"), Some("zero point one M".to_string()));
+        assert_eq!(parse("0.1 B"), Some("zero point one B".to_string()));
+        assert_eq!(parse("0.1 K"), Some("zero point one K".to_string()));
     }
 
     #[test]

--- a/src/tn/en/measure.rs
+++ b/src/tn/en/measure.rs
@@ -68,8 +68,9 @@ lazy_static! {
         m.insert("C", UnitInfo { singular: "degree celsius", plural: "degrees celsius" });
         m.insert("F", UnitInfo { singular: "degree fahrenheit", plural: "degrees fahrenheit" });
 
-        // Data
-        m.insert("B", UnitInfo { singular: "byte", plural: "bytes" });
+        // Data. Bare "B" is intentionally omitted: after a number an uppercase
+        // B/K/M/G/T is a magnitude abbreviation (billion, …) kept literal by the
+        // decimal tagger (NeMo). KB/MB/GB/TB still spell out as bytes.
         m.insert("KB", UnitInfo { singular: "kilobyte", plural: "kilobytes" });
         m.insert("MB", UnitInfo { singular: "megabyte", plural: "megabytes" });
         m.insert("GB", UnitInfo { singular: "gigabyte", plural: "gigabytes" });

--- a/tests/data/en/tn_decimal.txt
+++ b/tests/data/en/tn_decimal.txt
@@ -1,9 +1,12 @@
-# Decimal TN: written~spoken
-3.14~three point one four
-0.5~zero point five
-1.0~one point zero
-10.25~ten point two five
--3.14~minus three point one four
-1.5 billion~one point five billion
-4.85 billion~four point eight five billion
-2.5 million~two point five million
+.1665~point one six six five
+2.0~two point zero
+2.00~two point zero zero
+2.050~two point zero five zero
+100 million~one hundred million
+0.1 billion~zero point one billion
+.1 trillion~point one trillion
+-0.1~minus zero point one
+0.004~zero point zero zero four
+0.1 M~zero point one M
+0.1 B~zero point one B
+0.1 K~zero point one K


### PR DESCRIPTION
## TN-gap installment 3: decimal → 12/12

English TN `decimal` was **6/12** vs NeMo; this brings it to **12/12** (full class).

| Input | Was | Now |
|-------|-----|-----|
| `.1665` | zero point one six six five | **point** one six six five |
| `.1 trillion` | zero point one trillion | **point** one trillion |
| `100 million` | *(passthrough)* | one hundred million |
| `0.1 M` | *(passthrough)* | zero point one M |
| `0.1 B` | zero point one **bytes** | zero point one B |
| `0.1 K` | *(passthrough)* | zero point one K |

### Rules
- **Leading-dot** decimals omit the "zero" (`.1665` → "point one six six five"); `0.1` still keeps it.
- **Integer + scale word** (`100 million`) now spells out. Bare integers without a scale word stay the cardinal tagger's job (`100` → None here).
- **Single-letter magnitude abbreviations** (`K`/`M`/`B`/`G`/`T`, uppercase, space-separated) are kept verbatim — NeMo treats a trailing uppercase `B` as a *billion* abbreviation, not bytes.

### Cross-tagger note
Removes the **untested** bare `B`=bytes entry from the measure tagger, so `0.1 B` reaches decimal instead of becoming "zero point one bytes". `KB`/`MB`/`GB`/`TB` still spell out as bytes (those tests are unchanged).

### Tests
Re-vendors `tests/data/en/tn_decimal.txt` from the 12 upstream NeMo cases (asserting `test_tn_decimal` already present); adds unit coverage for each new rule. `parse` refactored into `spell_decimal`/`spell_integer`. Full suite green; new code clippy-clean.

## Running English TN parity
cardinal ✅ (#34) · fraction ✅ (#33) · **decimal ✅ (this)** — next partials: `ordinal` (23/26), `measure` (12/20), `time` (11/20), then the big ones (`money` 16/70, `date` 10/53).

🤖 Generated with [Claude Code](https://claude.com/claude-code)