### PR TITLE
fix(tn/es): stop panic on trailing multibyte char in ordinal tagger (125 crashes)

### DIFF
--- a/src/tn/es/ordinal.rs
+++ b/src/tn/es/ordinal.rs
@@ -87,7 +87,9 @@ pub fn parse(input: &str) -> Option<String> {
             }
         } else {
             let last = trimmed.chars().last()?;
-            let rest = &trimmed[..trimmed.len() - 1];
+            // Trim the last *character*, not the last byte — `trimmed` may end
+            // in a multibyte char (e.g. "1 £"), and slicing mid-char panics.
+            let rest = &trimmed[..trimmed.len() - last.len_utf8()];
             if last == 'a' && rest.chars().all(|c| c.is_ascii_digit()) && !rest.is_empty() {
                 (rest, true)
             } else if last == 'o' && rest.chars().all(|c| c.is_ascii_digit()) && !rest.is_empty() {
@@ -177,5 +179,14 @@ mod tests {
     fn test_non_ordinals() {
         assert_eq!(parse("hello"), None);
         assert_eq!(parse("0.o"), None);
+    }
+
+    #[test]
+    fn test_multibyte_suffix_does_not_panic() {
+        // Trailing multibyte chars must not be sliced mid-char (was a panic).
+        assert_eq!(parse("1 £"), None);
+        assert_eq!(parse("1 000.ª"), None);
+        assert_eq!(parse("5º"), None);
+        assert_eq!(parse("¥"), None);
     }
 }

--- a/tests/parity_baseline.tsv
+++ b/tests/parity_baseline.tsv
@@ -102,7 +102,7 @@ es	tn	ordinal	3	120
 es	tn	telephone	0	15
 es	tn	time	1	35
 es	tn	whitelist	0	7
-es	tn	word	47	48
+es	tn	word	48	48
 fr	itn	cardinal	106	106
 fr	itn	date	6	6
 fr	itn	decimal	15	15


### PR DESCRIPTION
## The crash
`tn::es::ordinal::parse` trimmed the last character with:
```rust
let rest = &trimmed[..trimmed.len() - 1];   // subtracts one BYTE
```
When the input ended in a multibyte char, the slice landed **mid-character** and panicked:
```
end byte index 3 is not a char boundary; it is inside '£' (bytes 2..4)
```
The new NeMo parity job surfaced this as **125 distinct crashing inputs** in the Spanish TN suite (`1 £`, `1 000.ª`, `1 001.ᵉʳ`, `5º`, currency symbols, …) — a library panic is worse than any coverage gap.

## Fix
Trim the last *character's* byte length instead of one byte:
```rust
let rest = &trimmed[..trimmed.len() - last.len_utf8()];
```
`last` is already in hand from `trimmed.chars().last()`.

## Verification
Ran the **full NeMo corpus** (ITN + TN, all 7 languages) through the port with `catch_unwind` per case:
- Before: **125 panics** (es TN).
- After: **0 panics** across every language/direction.

Adds a regression test (`test_multibyte_suffix_does_not_panic`) and refreshes the parity baseline (`es tn word` 47→48 — one case now returns correct output instead of crashing; the rest were failing either way, now gracefully).

## Follow-up (not in this PR)
A few other `&str` byte-slices in `zh`/`hi` taggers use the same one-byte pattern (`&s[..s.len()-1]`, `&after[1..]`). The NeMo corpus doesn't reach them, but they're latent multibyte panics worth a defensive sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)