### PR TITLE
feat(tn/en): money — NeMo "and" conventions, decimal-vs-cents, scale abbrevs (24→60/71)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1232,7 +1232,7 @@ fn normalize_sentence_inner(
 /// use text_processing_rs::tn_normalize;
 ///
 /// let result = tn_normalize("$5.50");
-/// assert_eq!(result, "five dollars and fifty cents");
+/// assert_eq!(result, "five dollars fifty cents");
 /// ```
 pub fn tn_normalize(input: &str) -> String {
     let input = input.trim();
@@ -1480,7 +1480,7 @@ mod tests {
 
     #[test]
     fn test_tn_money() {
-        assert_eq!(tn_normalize("$5.50"), "five dollars and fifty cents");
+        assert_eq!(tn_normalize("$5.50"), "five dollars fifty cents");
         assert_eq!(tn_normalize("$1"), "one dollar");
         assert_eq!(tn_normalize("$0.01"), "one cent");
     }

--- a/src/tn/en/money.rs
+++ b/src/tn/en/money.rs
@@ -1,13 +1,45 @@
 //! Money TN tagger.
 //!
 //! Converts written currency expressions to spoken form:
-//! - "$5.50" → "five dollars and fifty cents"
+//! - "$5.50" → "five dollars fifty cents"
 //! - "$1" → "one dollar"
 //! - "$0.01" → "one cent"
 //! - "€100" → "one hundred euros"
 //! - "$2.5 billion" → "two point five billion dollars"
 
-use super::number_to_words;
+use super::{number_to_words, number_to_words_and, spell_digits};
+
+/// Spell a non-negative money amount with NeMo's British "and": the multiplier
+/// groups (thousand and up) read plainly, while the final group takes an "and"
+/// — either inside the hundreds (`854` → "eight hundred and fifty four") or,
+/// when it is a bare sub-100 value after a larger part, in front of it
+/// (`18081` → "eighteen thousand and eighty one").
+fn amount_words(n: i64) -> String {
+    if n <= 0 {
+        return number_to_words(n);
+    }
+    let n = n as u128;
+    let units = (n % 1000) as u32;
+    let higher = n - u128::from(units);
+
+    if higher == 0 {
+        // Single group: use the within-hundreds "and" only.
+        return number_to_words_and(n);
+    }
+
+    let higher_words = number_to_words((higher) as i64);
+    match units {
+        0 => higher_words,
+        // Bare sub-100 final group takes a leading "and".
+        1..=99 => format!("{} and {}", higher_words, number_to_words(units as i64)),
+        // A hundreds final group carries its own internal "and".
+        _ => format!(
+            "{} {}",
+            higher_words,
+            number_to_words_and(u128::from(units))
+        ),
+    }
+}
 
 /// Currency info: (symbol, singular, plural, cent_singular, cent_plural)
 struct Currency {
@@ -98,21 +130,30 @@ pub fn parse(input: &str) -> Option<String> {
     // Parse the numeric amount
     if let Some(scale_word) = scale {
         // With scale: "$2.5 billion" → "two point five billion dollars"
+        // The multiplier before a scale word is not a final group, so it takes
+        // no "and" (`₩460 billion` → "four hundred sixty billion won").
         if amount_str.contains('.') {
             let parts: Vec<&str> = amount_str.splitn(2, '.').collect();
             if parts.len() == 2 {
                 let int_val: i64 = parts[0].parse().ok()?;
-                let int_words = number_to_words(int_val);
-                let frac_words = super::spell_digits(parts[1]);
+                let frac_words = spell_digits(parts[1]);
                 return Some(format!(
                     "{} point {} {} {}",
-                    int_words, frac_words, scale_word, currency.plural
+                    number_to_words(int_val),
+                    frac_words,
+                    scale_word,
+                    currency.plural
                 ));
             }
         } else {
-            let n: i64 = amount_str.parse().ok()?;
-            let words = number_to_words(n);
-            return Some(format!("{} {} {}", words, scale_word, currency.plural));
+            let clean: String = amount_str.chars().filter(|c| *c != ',').collect();
+            let n: i64 = clean.parse().ok()?;
+            return Some(format!(
+                "{} {} {}",
+                number_to_words(n),
+                scale_word,
+                currency.plural
+            ));
         }
     }
 
@@ -120,99 +161,109 @@ pub fn parse(input: &str) -> Option<String> {
     if amount_str.contains('.') {
         parse_dollars_cents(amount_str, currency)
     } else {
-        // Strip commas
         let clean: String = amount_str.chars().filter(|c| *c != ',').collect();
         let n: i64 = clean.parse().ok()?;
-        let words = number_to_words(n);
         let unit = if n == 1 {
             currency.singular
         } else {
             currency.plural
         };
-        Some(format!("{} {}", words, unit))
+        Some(format!("{} {}", amount_words(n), unit))
     }
 }
 
-/// Parse "$X.YY" → "X dollars and Y cents"
+/// Parse `$X.Y`. A fractional part that is a whole number of cents (≤ 2
+/// significant digits after trimming trailing zeros) reads as cents with no
+/// "and" — `$20.50` → "twenty dollars fifty cents". Otherwise it reads as a
+/// decimal amount — `$20.506` → "twenty point five zero six dollars".
 fn parse_dollars_cents(amount: &str, currency: &Currency) -> Option<String> {
-    let parts: Vec<&str> = amount.splitn(2, '.').collect();
-    if parts.len() != 2 {
-        return None;
+    let (int_str, frac_str) = amount.split_once('.')?;
+    let int_clean: String = int_str.chars().filter(|c| *c != ',').collect();
+
+    // More than two significant fractional digits → spoken as a decimal.
+    if frac_str.trim_end_matches('0').len() > 2 {
+        let frac_words = spell_digits(frac_str);
+        if int_clean.is_empty() {
+            return Some(format!("point {} {}", frac_words, currency.plural));
+        }
+        let int_val: i64 = int_clean.parse().ok()?;
+        return Some(format!(
+            "{} point {} {}",
+            amount_words(int_val),
+            frac_words,
+            currency.plural
+        ));
     }
 
-    let dollars: i64 = if parts[0].is_empty() {
+    // Whole cents.
+    let dollars: i64 = if int_clean.is_empty() {
         0
     } else {
-        parts[0].parse().ok()?
+        int_clean.parse().ok()?
     };
-    let cents_str = parts[1];
-
-    // Pad or truncate cents to 2 digits
-    let cents: i64 = if cents_str.is_empty() {
-        0
-    } else if cents_str.len() == 1 {
-        cents_str.parse::<i64>().ok()? * 10
-    } else if cents_str.len() == 2 {
-        cents_str.parse().ok()?
-    } else {
-        // More than 2 decimal places — take first 2
-        cents_str[..2].parse().ok()?
+    let cents: i64 = match frac_str.trim_end_matches('0') {
+        "" => 0,
+        one if one.len() == 1 => one.parse::<i64>().ok()? * 10,
+        two => two.parse().ok()?,
     };
 
-    if dollars == 0 && cents == 0 {
-        return Some(format!("zero {}", currency.plural));
-    }
-
-    if dollars == 0 {
-        let cents_words = number_to_words(cents);
-        let unit = if cents == 1 {
-            currency.cent_singular
-        } else {
-            currency.cent_plural
-        };
-        return Some(format!("{} {}", cents_words, unit));
-    }
-
-    if cents == 0 {
-        let dollar_words = number_to_words(dollars);
+    let dollar_part = (dollars != 0).then(|| {
         let unit = if dollars == 1 {
             currency.singular
         } else {
             currency.plural
         };
-        return Some(format!("{} {}", dollar_words, unit));
+        format!("{} {}", amount_words(dollars), unit)
+    });
+    let cent_part = (cents != 0).then(|| {
+        let unit = if cents == 1 {
+            currency.cent_singular
+        } else {
+            currency.cent_plural
+        };
+        format!("{} {}", amount_words(cents), unit)
+    });
+
+    match (dollar_part, cent_part) {
+        (Some(d), Some(c)) => Some(format!("{} {}", d, c)),
+        (Some(d), None) => Some(d),
+        (None, Some(c)) => Some(c),
+        (None, None) => Some(format!("zero {}", currency.plural)),
     }
-
-    let dollar_words = number_to_words(dollars);
-    let cents_words = number_to_words(cents);
-    let dollar_unit = if dollars == 1 {
-        currency.singular
-    } else {
-        currency.plural
-    };
-    let cent_unit = if cents == 1 {
-        currency.cent_singular
-    } else {
-        currency.cent_plural
-    };
-
-    Some(format!(
-        "{} {} and {} {}",
-        dollar_words, dollar_unit, cents_words, cent_unit
-    ))
 }
 
-/// Extract scale suffix from the amount string.
+/// Single-letter magnitude abbreviations after an amount (`¥30b`).
+const SCALE_ABBREVS: &[(&str, &str)] = &[
+    ("b", "billion"),
+    ("m", "million"),
+    ("k", "thousand"),
+    ("t", "trillion"),
+];
+
+/// Extract a trailing scale word or single-letter magnitude abbreviation.
 fn extract_scale(input: &str) -> (&str, Option<&str>) {
+    let numeric = |s: &str| {
+        !s.is_empty()
+            && s.chars()
+                .all(|c| c.is_ascii_digit() || c == '.' || c == ',')
+    };
+
     for &scale in SCALE_SUFFIXES {
         if let Some(before) = input.strip_suffix(scale) {
             let before = before.trim_end();
-            if !before.is_empty()
-                && before
-                    .chars()
-                    .all(|c| c.is_ascii_digit() || c == '.' || c == ',')
-            {
+            if numeric(before) {
                 return (before, Some(scale));
+            }
+        }
+    }
+    // `30b` / `30 B` → billion. Case-insensitive; requires a numeric amount
+    // immediately (optionally space-separated) before the letter.
+    if let Some(last) = input.chars().last() {
+        let lower = last.to_ascii_lowercase().to_string();
+        if let Some(&(_, word)) = SCALE_ABBREVS.iter().find(|(a, _)| *a == lower) {
+            let before = input[..input.len() - last.len_utf8()].trim_end();
+            if numeric(before) {
+                return (before, Some(word));
             }
         }
     }
@@ -232,13 +283,41 @@ mod tests {
 
     #[test]
     fn test_dollars_and_cents() {
-        assert_eq!(
-            parse("$5.50"),
-            Some("five dollars and fifty cents".to_string())
-        );
-        assert_eq!(parse("$1.01"), Some("one dollar and one cent".to_string()));
+        // NeMo: no "and" between the dollar and cent parts.
+        assert_eq!(parse("$5.50"), Some("five dollars fifty cents".to_string()));
+        assert_eq!(parse("$1.01"), Some("one dollar one cent".to_string()));
         assert_eq!(parse("$0.01"), Some("one cent".to_string()));
         assert_eq!(parse("$0.99"), Some("ninety nine cents".to_string()));
+        // Trailing zeros trimmed to whole cents.
+        assert_eq!(
+            parse("$20.500"),
+            Some("twenty dollars fifty cents".to_string())
+        );
+    }
+
+    #[test]
+    fn test_british_and_in_amount() {
+        assert_eq!(
+            parse("$18854"),
+            Some("eighteen thousand eight hundred and fifty four dollars".to_string())
+        );
+        // Bare sub-100 final group after a larger part takes a leading "and".
+        assert_eq!(
+            parse("$18081"),
+            Some("eighteen thousand and eighty one dollars".to_string())
+        );
+    }
+
+    #[test]
+    fn test_more_than_two_decimals_reads_as_decimal() {
+        assert_eq!(
+            parse("$20.506"),
+            Some("twenty point five zero six dollars".to_string())
+        );
+        assert_eq!(
+            parse("$.506"),
+            Some("point five zero six dollars".to_string())
+        );
     }
 
     #[test]
@@ -251,6 +330,13 @@ mod tests {
             parse("$50 million"),
             Some("fifty million dollars".to_string())
         );
+        // Multiplier before a scale word takes no "and".
+        assert_eq!(
+            parse("₩460 billion"),
+            Some("four hundred sixty billion won".to_string())
+        );
+        // Single-letter magnitude abbreviation.
+        assert_eq!(parse("¥30b"), Some("thirty billion yen".to_string()));
     }
 
     #[test]

--- a/swift-test/Sources/NemoTest/NemoTest.swift
+++ b/swift-test/Sources/NemoTest/NemoTest.swift
@@ -253,7 +253,7 @@ let tnOrdinalTests: [TC] = [
 let tnMoneyTests: [TC] = [
     ("$1", "one dollar"),
     ("$5", "five dollars"),
-    ("$5.50", "five dollars and fifty cents"),
+    ("$5.50", "five dollars fifty cents"),
     ("$0.01", "one cent"),
     ("$0.99", "ninety nine cents"),
     ("\u{00A3}1", "one pound"),

--- a/tests/data/en/tn_money.txt
+++ b/tests/data/en/tn_money.txt
@@ -1,17 +1,65 @@
-# Money TN: written~spoken
+# English money TN cases (NeMo conventions).
+# Curated to the cases the port passes; omitted upstream cases need
+# cross-class support not yet implemented: word-form currencies (yuan,
+# US dollars), ranges ($50-$100), per-unit rates ($20/mo), and
+# full-sentence contexts.
+$2~two dollars
+$2.00~two dollars
+₩460 billion~four hundred sixty billion won
+¥30 billion~thirty billion yen
+¥30 b~thirty billion yen
+¥30b~thirty billion yen
+¥30B~thirty billion yen
+$45 billion~forty five billion dollars
+$0.2 million~zero point two million dollars
+$2.5 million~two point five million dollars
+$15.2 billion~fifteen point two billion dollars
+$15000~fifteen thousand dollars
 $1~one dollar
-$5~five dollars
-$100~one hundred dollars
-$5.50~five dollars and fifty cents
-$1.01~one dollar and one cent
-$0.01~one cent
-$0.99~ninety nine cents
-$0.50~fifty cents
-$1,000~one thousand dollars
-€100~one hundred euros
-€1~one euro
-£1~one pound
-£5.50~five pounds and fifty pence
-¥500~five hundred yen
-$2.5 billion~two point five billion dollars
-$50 million~fifty million dollars
+$1.00~one dollar
+$1.00~one dollar
+$2~two dollars
+$2.00~two dollars
+$2.000~two dollars
+$20~twenty dollars
+$20.506~twenty point five zero six dollars
+$20.50~twenty dollars fifty cents
+$20.500~twenty dollars fifty cents
+$20.5~twenty dollars fifty cents
+$20.01~twenty dollars one cent
+$20.010~twenty dollars one cent
+$0.010~one cent
+$0.02~two cents
+$0.20~twenty cents
+$.01~one cent
+$.506~point five zero six dollars
+$18~eighteen dollars
+$18925000~eighteen million nine hundred twenty five thousand dollars
+$18,925,000~eighteen million nine hundred twenty five thousand dollars
+$18854~eighteen thousand eight hundred and fifty four dollars
+$18801~eighteen thousand eight hundred and one dollars
+$18875~eighteen thousand eight hundred and seventy five dollars
+$18081~eighteen thousand and eighty one dollars
+$18052~eighteen thousand and fifty two dollars
+$18542~eighteen thousand five hundred and forty two dollars
+$18519~eighteen thousand five hundred and nineteen dollars
+$18570~eighteen thousand five hundred and seventy dollars
+$18578~eighteen thousand five hundred and seventy eight dollars
+$18516~eighteen thousand five hundred and sixteen dollars
+$18482~eighteen thousand four hundred and eighty two dollars
+$18478~eighteen thousand four hundred and seventy eight dollars
+$18468~eighteen thousand four hundred and sixty eight dollars
+$18903~eighteen thousand nine hundred and three dollars
+$18929~eighteen thousand nine hundred and twenty nine dollars
+$18095~eighteen thousand and ninety five dollars
+$18117~eighteen thousand one hundred and seventeen dollars
+$18128~eighteen thousand one hundred and twenty eight dollars
+$18125~eighteen thousand one hundred and twenty five dollars
+$18124~eighteen thousand one hundred and twenty four dollars
+$18129~eighteen thousand one hundred and twenty nine dollars
+£18000~eighteen thousand pounds
+£1.20~one pound twenty pence
+£1.111~one point one one one pounds
+£2.01~two pounds one penny
+$1,925.21~one thousand nine hundred and twenty five dollars twenty one cents
+$1,234.123~one thousand two hundred and thirty four point one two three dollars

--- a/tests/extensive_tests.rs
+++ b/tests/extensive_tests.rs
@@ -594,7 +594,7 @@ fn test_tn_money_various_currencies() {
 
 #[test]
 fn test_tn_money_pounds_pence() {
-    assert_eq!(tn_normalize("£1.50"), "one pound and fifty pence");
+    assert_eq!(tn_normalize("£1.50"), "one pound fifty pence");
     assert_eq!(tn_normalize("£0.01"), "one penny");
 }
 
@@ -616,7 +616,7 @@ fn test_tn_money_just_symbol_no_parse() {
 #[test]
 fn test_tn_money_large_cents() {
     // "$5.5" = $5.50 (single decimal digit)
-    assert_eq!(tn_normalize("$5.5"), "five dollars and fifty cents");
+    assert_eq!(tn_normalize("$5.5"), "five dollars fifty cents");
 }
 
 // ════════════════════════════════════════════════════════════════════════
@@ -1097,7 +1097,7 @@ fn test_roundtrip_cardinal_large() {
 #[test]
 fn test_roundtrip_money() {
     let spoken = tn_normalize("$5.50");
-    assert_eq!(spoken, "five dollars and fifty cents");
+    assert_eq!(spoken, "five dollars fifty cents");
     let back = normalize(&spoken);
     assert_eq!(back, "$5.50");
 }
@@ -1290,7 +1290,7 @@ fn test_tts_scenario_address() {
 fn test_tts_scenario_price() {
     let result = tn_normalize_sentence("The laptop costs $1,299");
     assert!(
-        result.contains("one thousand two hundred ninety nine dollars"),
+        result.contains("one thousand two hundred and ninety nine dollars"),
         "Price should be spoken: {}",
         result
     );

--- a/tests/parity_baseline.tsv
+++ b/tests/parity_baseline.tsv
@@ -55,7 +55,7 @@ en	tn	electronic	0	45
 en	tn	fraction	16	16
 en	tn	math	0	4
 en	tn	measure	1	21
-en	tn	money	24	71
+en	tn	money	60	71
 en	tn	normalize_with_audio	0	58
 en	tn	ordinal	18	27
 en	tn	punctuation	15	63

--- a/wasm-tests/node-smoke.mjs
+++ b/wasm-tests/node-smoke.mjs
@@ -23,7 +23,7 @@ assertEqual(
   'I have 21 apples',
   'normalizeSentence should convert spans'
 );
-assertEqual(wasm.tnNormalize('$5.50'), 'five dollars and fifty cents', 'tnNormalize should work');
+assertEqual(wasm.tnNormalize('$5.50'), 'five dollars fifty cents', 'tnNormalize should work');
 assertEqual(
   wasm.tnNormalizeSentence('I paid $5 for 23 items'),
   'I paid five dollars for twenty three items',


### PR DESCRIPTION
## TN-gap installment: money → 60/71

English TN `money` was **24/71** vs NeMo; this brings it to **60/71**.

| Input | Was | Now |
|-------|-----|-----|
| `$18854` | eighteen thousand eight hundred fifty four dollars | eighteen thousand eight hundred **and** fifty four dollars |
| `$18081` | eighteen thousand eighty one dollars | eighteen thousand **and** eighty one dollars |
| `$20.50` | twenty dollars **and** fifty cents | twenty dollars fifty cents |
| `$20.506` | twenty dollars fifty cents | twenty point five zero six dollars |
| `$.506` | fifty cents | point five zero six dollars |
| `₩460 billion` | four hundred **and** sixty billion won | four hundred sixty billion won |
| `¥30b` | ¥30b | thirty billion yen |

### Rules
- **British "and", money-style:** multiplier groups (thousand+) read plainly; the *final* group takes an "and" — inside the hundreds (`854`→"eight hundred **and** fifty four") or before a bare sub-100 final group (`18081`→"…thousand **and** eighty one"). This differs from cardinal's rule, matching NeMo's money verbalizer.
- **No "and" between dollars and cents.**
- **Decimal-vs-cents:** a fractional part that is a whole number of cents (≤2 significant digits after trimming trailing zeros) → cents; otherwise → decimal amount reading.
- **Scale multiplier takes no "and";** single-letter magnitude abbreviations (`b`/`m`/`k`/`t`).

### Curated out (cross-class, documented in the data file)
The 11 remaining upstream cases need machinery not yet present: word-form currencies (`yuan`, `US $`), ranges (`$50-$100`), per-unit rates (`$20/mo`), and full-sentence contexts.

### Tests
Re-vendors `tests/data/en/tn_money.txt` to the 60 passing NeMo cases; updates the port's own money TN assertions, the `tn_normalize` doctest, and the **Swift FFI harness** (`$5.50` no longer "and"); refreshes the parity baseline (`en tn money` 24→60). Full suite green (1092 tests); new code clippy-clean.

Running English TN: cardinal 17/18 · decimal 12/12 · fraction 16/16 · ordinal 18/27 · **money 60/71**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)