### PR TITLE
feat(tn/en): date — bare 4-digit years read year-style (13→19/54)

### DIFF
--- a/src/tn/en/date.rs
+++ b/src/tn/en/date.rs
@@ -57,7 +57,28 @@ pub fn parse(input: &str) -> Option<String> {
         return Some(result);
     }
 
+    // Bare 4-digit year → year-style reading ("1994" → "nineteen ninety
+    // four"). Out-of-range values fall through to the cardinal tagger.
+    if let Some(result) = parse_bare_year(trimmed) {
+        return Some(result);
+    }
+
     None
+}
+
+/// A standalone 4-digit number in a plausible year range (1000–2099) reads
+/// year-style. Other 4-digit numbers are left for the cardinal tagger.
+fn parse_bare_year(input: &str) -> Option<String> {
+    if input.len() != 4 || !input.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    let year: u32 = input.parse().ok()?;
+    // Round centuries (1000, 1900, 2000, …) are ambiguous and read better as
+    // cardinals ("one thousand", "two thousand"), so leave them.
+    if !(1000..=2099).contains(&year) || year.is_multiple_of(100) {
+        return None;
+    }
+    verbalize_year(year)
 }
 
 /// Pluralize the final word of a spelled decade into its `-s`/`-ies` form,
@@ -372,6 +393,18 @@ mod tests {
             parse("July 4, 1776"),
             Some("july fourth seventeen seventy six".to_string())
         );
+    }
+
+    #[test]
+    fn test_bare_year() {
+        assert_eq!(parse("1994"), Some("nineteen ninety four".to_string()));
+        assert_eq!(parse("2012"), Some("twenty twelve".to_string()));
+        assert_eq!(parse("1155"), Some("eleven fifty five".to_string()));
+        // Round centuries and out-of-range values fall through to cardinal.
+        assert_eq!(parse("1000"), None);
+        assert_eq!(parse("2000"), None);
+        assert_eq!(parse("9000"), None);
+        assert_eq!(parse("123"), None);
     }
 
     #[test]

--- a/tests/data/en/tn_date.txt
+++ b/tests/data/en/tn_date.txt
@@ -1,11 +1,23 @@
-# Date TN: written~spoken
-January 5~january fifth
-December 25~december twenty fifth
-January 5, 2025~january fifth twenty twenty five
-July 4, 1776~july fourth seventeen seventy six
+# English date TN cases (NeMo conventions).
+# Curated to the cases the port passes; omitted upstream cases need
+# formats not yet implemented: British "the Nth of Month", abbreviated/
+# cased months, numeric YYYY-MM-DD / DD.MM.YYYY, quarters, and sentences.
+july 25 2012~july twenty fifth twenty twelve
 1980s~nineteen eighties
-1990s~nineteen nineties
+january 1~january first
+june 30~june thirtieth
+2012~twenty twelve
+1994~nineteen ninety four
+1976~nineteen seventy six
+june 20 2014~june twentieth twenty fourteen
+1973~nineteen seventy three
+1975~nineteen seventy five
+1155~eleven fifty five
+august 23 2002~august twenty third two thousand two
+1980s~nineteen eighties
+10/06/2005~october sixth two thousand five
+1910s~nineteen tens
 2000s~two thousands
-1/5/2025~january fifth twenty twenty five
-12/25/2000~december twenty fifth two thousand
-March 1~march first
+1000~one thousand
+01/07/98~january seventh ninety eight
+'80s~eighties

--- a/tests/extensive_tests.rs
+++ b/tests/extensive_tests.rs
@@ -1237,10 +1237,9 @@ fn test_interference_decimal_vs_money() {
 
 #[test]
 fn test_interference_tn_number_vs_date() {
-    // "1980" alone should not be treated as a date by TN
-    // It should be treated as a cardinal number
+    // A bare 4-digit number in year range reads year-style (NeMo).
     let result = tn_normalize("1980");
-    assert_eq!(result, "one thousand nine hundred and eighty");
+    assert_eq!(result, "nineteen eighty");
 }
 
 #[test]

--- a/tests/parity_baseline.tsv
+++ b/tests/parity_baseline.tsv
@@ -49,7 +49,7 @@ en	itn	word	55	55
 en	itn	word_cased	49	49
 en	tn	address	1	11
 en	tn	cardinal	17	18
-en	tn	date	13	54
+en	tn	date	19	54
 en	tn	decimal	12	12
 en	tn	electronic	0	45
 en	tn	fraction	16	16


### PR DESCRIPTION
## TN-gap installment: date bare-year rule

English TN `date` 13/54 → **19/54**. Adds the cleanest, most TTS-valuable sub-group: a standalone 4-digit number in a plausible year range reads **year-style**.

| Input | Was | Now |
|-------|-----|-----|
| `1994` | one thousand nine hundred and ninety four | nineteen ninety four |
| `2012` | two thousand twelve | twenty twelve |
| `1155` | one thousand one hundred and fifty five | eleven fifty five |
| `1000` | one thousand | one thousand *(unchanged)* |
| `2000` | two thousand | two thousand *(unchanged)* |
| `9000` | nine thousand | nine thousand *(unchanged)* |

### Rule
A bare 4-digit number in **1000–2099** reads year-style via the existing `verbalize_year`. **Round centuries** (1000, 1900, 2000, …) and out-of-range values fall through to the cardinal tagger — so `1000` stays "one thousand" and cardinal parity is untouched. This is also the reading TTS wants for years (cf. FluidAudio #776).

### Curated out (documented in the data file)
The remaining upstream date cases need format families not yet implemented: British "the Nth of Month" (`25 july 2012`), abbreviated/cased months (`Jan. 15`, `SEPT. 15`), numeric `YYYY-MM-DD`/`DD.MM.YYYY`/`DD-MM-YYYY`, quarters (`2Q22`), and full-sentence contexts.

### Tests
Updates the port's own number-vs-date interference test to the year form, adds `test_bare_year`, re-vendors `tests/data/en/tn_date.txt` to the 19 passing NeMo cases, refreshes the parity baseline (`en tn date` 13→19). Swift/WASM harnesses have no bare-year assertions. Full suite green (1092 tests); new code clippy-clean.

Running English TN: cardinal 17/18 · decimal 12/12 · fraction 16/16 · money 60/71 · ordinal 18/27 · **date 19/54**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)