### PR TITLE
feat(tn/en): add math tagger (0/4 → 4/4)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1240,6 +1240,9 @@ pub fn tn_normalize(input: &str) -> String {
     if let Some(result) = tn::en::whitelist::parse(input) {
         return result;
     }
+    if let Some(result) = tn::en::math::parse(input) {
+        return result;
+    }
     if let Some(result) = tn::en::money::parse(input) {
         return result;
     }
@@ -1284,6 +1287,9 @@ fn tn_parse_span(span: &str) -> Option<(String, u8)> {
 
     if let Some(result) = tn::en::whitelist::parse(span) {
         return Some((result, 100));
+    }
+    if let Some(result) = tn::en::math::parse(span) {
+        return Some((result, 96));
     }
     if let Some(result) = tn::en::money::parse(span) {
         return Some((result, 95));

--- a/src/tn/en/math.rs
+++ b/src/tn/en/math.rs
@@ -1,0 +1,86 @@
+//! Math TN tagger.
+//!
+//! Converts simple written math expressions to spoken form:
+//! - "1-2=5" → "one minus two equals five"
+//! - "y=x +1" → "y equals x plus one"
+//!
+//! Requires an `=` so it never fires on bare hyphenated/serial tokens.
+
+use super::number_to_words;
+
+/// Parse a math expression to spoken form. Operands are integers or
+/// single-word variables; operators are `+ - * / =`.
+pub fn parse(input: &str) -> Option<String> {
+    let trimmed = input.trim();
+    if !trimmed.contains('=') {
+        return None;
+    }
+
+    // Space out the operators so a plain whitespace split yields tokens.
+    let spaced = trimmed
+        .replace('=', " = ")
+        .replace('+', " + ")
+        .replace('-', " - ")
+        .replace('*', " * ")
+        .replace('/', " / ");
+
+    let mut words: Vec<String> = Vec::new();
+    for token in spaced.split_whitespace() {
+        let word = match token {
+            "=" => "equals".to_string(),
+            "+" => "plus".to_string(),
+            "-" => "minus".to_string(),
+            "*" => "times".to_string(),
+            "/" => "divided by".to_string(),
+            t if t.bytes().all(|b| b.is_ascii_digit()) => {
+                let n: i64 = t.parse().ok()?;
+                number_to_words(n)
+            }
+            // A bare variable (letters only) is kept verbatim.
+            t if t.bytes().all(|b| b.is_ascii_alphabetic()) => t.to_string(),
+            // Anything mixed (e.g. "x86", "5.4") is not a clean math token.
+            _ => return None,
+        };
+        words.push(word);
+    }
+
+    if words.is_empty() {
+        return None;
+    }
+    Some(words.join(" "))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic() {
+        assert_eq!(
+            parse("1-2=5"),
+            Some("one minus two equals five".to_string())
+        );
+        assert_eq!(
+            parse("1- 2 = 5"),
+            Some("one minus two equals five".to_string())
+        );
+    }
+
+    #[test]
+    fn test_variables() {
+        assert_eq!(parse("y=x +1"), Some("y equals x plus one".to_string()));
+        assert_eq!(parse("x +1 = y"), Some("x plus one equals y".to_string()));
+    }
+
+    #[test]
+    fn test_requires_equals() {
+        // No "=" → not this tagger's job (avoids ranges/serials).
+        assert_eq!(parse("2-5"), None);
+        assert_eq!(parse("hello"), None);
+    }
+
+    #[test]
+    fn test_rejects_mixed_tokens() {
+        assert_eq!(parse("x86 = y"), None);
+    }
+}

--- a/src/tn/en/mod.rs
+++ b/src/tn/en/mod.rs
@@ -10,6 +10,7 @@ pub mod date;
 pub mod decimal;
 pub mod electronic;
 pub mod fraction;
+pub mod math;
 pub mod measure;
 pub mod money;
 pub mod ordinal;

--- a/tests/data/en/tn_math.txt
+++ b/tests/data/en/tn_math.txt
@@ -1,0 +1,4 @@
+1-2=5~one minus two equals five
+1- 2 = 5~one minus two equals five
+y=x +1~y equals x plus one
+x +1 = y~x plus one equals y

--- a/tests/en_tn_tests.rs
+++ b/tests/en_tn_tests.rs
@@ -278,3 +278,20 @@ fn test_tn_fraction() {
         results.failures.len()
     );
 }
+
+#[test]
+fn test_tn_math() {
+    let results = common::run_test_file(Path::new("tests/data/en/tn_math.txt"), tn_normalize);
+    println!(
+        "tn_math: {}/{} passed ({} failures)",
+        results.passed,
+        results.total,
+        results.failures.len()
+    );
+    print_failures(&results);
+    assert!(
+        results.failures.is_empty(),
+        "{} math TN tests failed",
+        results.failures.len()
+    );
+}

--- a/tests/parity_baseline.tsv
+++ b/tests/parity_baseline.tsv
@@ -53,12 +53,12 @@ en	tn	date	19	54
 en	tn	decimal	12	12
 en	tn	electronic	0	45
 en	tn	fraction	16	16
-en	tn	math	0	4
+en	tn	math	4	4
 en	tn	measure	1	21
 en	tn	money	60	71
 en	tn	normalize_with_audio	0	58
 en	tn	ordinal	18	27
-en	tn	punctuation	15	63
+en	tn	punctuation	16	63
 en	tn	punctuation_match_input	1	13
 en	tn	range	0	20
 en	tn	roman	1	4


### PR DESCRIPTION
## TN-gap installment: math

New `tn::en::math` — the `math` class was 0/4, now **4/4**.

| Input | Output |
|-------|--------|
| `1-2=5` | one minus two equals five |
| `1- 2 = 5` | one minus two equals five |
| `y=x +1` | y equals x plus one |
| `x +1 = y` | x plus one equals y |

### Rule
Operators (`+ - * / =`) map to words, integer operands spell out, single-word variables are kept verbatim. **Gated on `=`** so it never fires on bare hyphenated/serial tokens (`2-5`, `a-b`) — mixed tokens (`x86`, `5.4`) also bail out. Wired into both the single-expression and sentence-mode dispatch after `whitelist` (a high-specificity signal).

### Tests
Vendors the 4 NeMo cases with an asserting `test_tn_math`, plus unit coverage (basic / variables / requires-equals / rejects-mixed). Refreshes parity baseline (`en tn math` 0→4). Full suite green; clippy-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)