### PR TITLE
feat(tn/en): roman — keyword-anchored numerals (1/4 → 3/4)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1243,6 +1243,9 @@ pub fn tn_normalize(input: &str) -> String {
     if let Some(result) = tn::en::math::parse(input) {
         return result;
     }
+    if let Some(result) = tn::en::roman::parse(input) {
+        return result;
+    }
     if let Some(result) = tn::en::money::parse(input) {
         return result;
     }
@@ -1290,6 +1293,9 @@ fn tn_parse_span(span: &str) -> Option<(String, u8)> {
     }
     if let Some(result) = tn::en::math::parse(span) {
         return Some((result, 96));
+    }
+    if let Some(result) = tn::en::roman::parse(span) {
+        return Some((result, 94));
     }
     if let Some(result) = tn::en::money::parse(span) {
         return Some((result, 95));

--- a/src/tn/en/mod.rs
+++ b/src/tn/en/mod.rs
@@ -14,6 +14,7 @@ pub mod math;
 pub mod measure;
 pub mod money;
 pub mod ordinal;
+pub mod roman;
 pub mod telephone;
 pub mod time;
 pub mod whitelist;

--- a/src/tn/en/roman.rs
+++ b/src/tn/en/roman.rs
@@ -1,0 +1,93 @@
+//! Roman-numeral TN tagger.
+//!
+//! Converts a roman numeral that follows a section keyword to a cardinal:
+//! - "Chapter IV" → "Chapter four"
+//! - "PART XL" → "PART forty"
+//!
+//! Only the keyword-anchored form is handled. NeMo also reads a numeral after
+//! a personal name as an ordinal ("Sam II" → "Sam second"), but that relies on
+//! a large name list; without it a bare-capitalized heuristic over-fires on
+//! ordinary words, so it is intentionally left out.
+
+use super::number_to_words;
+
+/// Section words that mark a following roman numeral as a cardinal. Matched
+/// case-insensitively; the prefix is echoed back with its original casing.
+const KEYWORDS: &[&str] = &[
+    "chapter",
+    "class",
+    "part",
+    "article",
+    "section",
+    "paragraph",
+];
+
+/// Parse a `"<keyword> <roman>"` pair to spoken form.
+pub fn parse(input: &str) -> Option<String> {
+    let trimmed = input.trim();
+    let (prefix, roman) = trimmed.split_once(' ')?;
+    if !KEYWORDS.contains(&prefix.to_lowercase().as_str()) {
+        return None;
+    }
+    let value = roman_to_int(roman.trim())?;
+    Some(format!("{} {}", prefix, number_to_words(value)))
+}
+
+/// Convert a roman numeral to its value, or `None` if it is not a valid
+/// numeral (empty, or containing a non-roman letter).
+fn roman_to_int(s: &str) -> Option<i64> {
+    if s.is_empty() {
+        return None;
+    }
+    let mut total = 0i64;
+    let mut prev = 0i64;
+    for c in s.chars().rev() {
+        let value = match c.to_ascii_uppercase() {
+            'I' => 1,
+            'V' => 5,
+            'X' => 10,
+            'L' => 50,
+            'C' => 100,
+            'D' => 500,
+            'M' => 1000,
+            _ => return None,
+        };
+        if value < prev {
+            total -= value;
+        } else {
+            total += value;
+            prev = value;
+        }
+    }
+    Some(total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_keyword_cardinal() {
+        assert_eq!(parse("Chapter IV"), Some("Chapter four".to_string()));
+        assert_eq!(parse("PART XL"), Some("PART forty".to_string()));
+        assert_eq!(parse("section iii"), Some("section three".to_string()));
+        assert_eq!(parse("Article XII"), Some("Article twelve".to_string()));
+    }
+
+    #[test]
+    fn test_not_roman() {
+        assert_eq!(parse("Chapter Five"), None); // not a numeral
+        assert_eq!(parse("Sam II"), None); // name path not handled
+        assert_eq!(parse("hello world"), None);
+        assert_eq!(parse("Chapter"), None);
+    }
+
+    #[test]
+    fn test_roman_values() {
+        assert_eq!(roman_to_int("IV"), Some(4));
+        assert_eq!(roman_to_int("XL"), Some(40));
+        assert_eq!(roman_to_int("MCMXciv"), Some(1994));
+        assert_eq!(roman_to_int("IIII"), Some(4)); // lax: additive form allowed
+        assert_eq!(roman_to_int("hi"), None);
+    }
+}

--- a/tests/data/en/tn_roman.txt
+++ b/tests/data/en/tn_roman.txt
@@ -1,0 +1,7 @@
+# English roman-numeral TN cases (NeMo conventions).
+# The name-anchored ordinal form ("Sam II" -> "Sam second") is omitted:
+# it needs NeMo's ~8k-name list, and a bare-capitalized heuristic would
+# over-fire on ordinary words.
+Chapter IV~Chapter four
+PART XL~PART forty
+Sam and I~Sam and I

--- a/tests/en_tn_tests.rs
+++ b/tests/en_tn_tests.rs
@@ -295,3 +295,20 @@ fn test_tn_math() {
         results.failures.len()
     );
 }
+
+#[test]
+fn test_tn_roman() {
+    let results = common::run_test_file(Path::new("tests/data/en/tn_roman.txt"), tn_normalize);
+    println!(
+        "tn_roman: {}/{} passed ({} failures)",
+        results.passed,
+        results.total,
+        results.failures.len()
+    );
+    print_failures(&results);
+    assert!(
+        results.failures.is_empty(),
+        "{} roman TN tests failed",
+        results.failures.len()
+    );
+}

--- a/tests/parity_baseline.tsv
+++ b/tests/parity_baseline.tsv
@@ -61,7 +61,7 @@ en	tn	ordinal	18	27
 en	tn	punctuation	16	63
 en	tn	punctuation_match_input	1	13
 en	tn	range	0	20
-en	tn	roman	1	4
+en	tn	roman	3	4
 en	tn	serial	0	32
 en	tn	special_text	9	10
 en	tn	telephone	12	20


### PR DESCRIPTION
## TN-gap installment: roman

New `tn::en::roman` — `roman` was 1/4, now **3/4**.

| Input | Output |
|-------|--------|
| `Chapter IV` | Chapter four |
| `PART XL` | PART forty |
| `Section iii` | section three |
| `Sam and I` | Sam and I *(unchanged)* |

### Rule
A roman numeral after a **section keyword** (chapter/class/part/article/section/paragraph, case-insensitive) reads as a cardinal; the prefix keeps its original casing. Wired into both dispatchers after `math`.

### Deliberately omitted
NeMo also reads a numeral after a **personal name** as an ordinal (`Sam II`→"Sam second"), but that relies on NeMo's ~8,000-entry name list. A bare-capitalized heuristic would over-fire on ordinary words (`The X`→"The tenth"), so that path is left out and its case documented in the vendored data. That's the 1 remaining case (3/4, not 4/4).

### Tests
Vendors the 3 passing NeMo cases with an asserting `test_tn_roman`, plus unit coverage (keyword→cardinal, non-roman rejection, roman-value parsing). Refreshes parity baseline (`en tn roman` 1→3). Full suite green; clippy-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)