### PR TITLE
feat(tn/en): rewrite time tagger to NeMo conventions (0 → 20/21)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1508,7 +1508,7 @@ mod tests {
     fn test_tn_time() {
         assert_eq!(tn_normalize("2:30"), "two thirty");
         assert_eq!(tn_normalize("2:05"), "two oh five");
-        assert_eq!(tn_normalize("2:00 PM"), "two p m");
+        assert_eq!(tn_normalize("2:00 PM"), "two PM");
     }
 
     #[test]

--- a/src/tn/en/time.rs
+++ b/src/tn/en/time.rs
@@ -1,100 +1,180 @@
 //! Time TN tagger.
 //!
-//! Converts written time expressions to spoken form:
-//! - "2:30" → "two thirty"
-//! - "2:05" → "two oh five"
-//! - "2:00 PM" → "two p m"
-//! - "14:00" → "two p m"
-//! - "2:30 AM" → "two thirty a m"
+//! Converts written clock times to spoken form (NeMo conventions):
+//! - "01:00" → "one o'clock"      (minute zero, no meridiem)
+//! - "23:00" → "twenty three o'clock" (24-hour clock kept as-is)
+//! - "01:00 am" → "one AM"        (minute zero + meridiem)
+//! - "1:59 p.m. est" → "one fifty nine PM EST"
+//! - "1:01:01" → "one hour one minute and one second"
+//! - "5pm" → "five PM", "1.59 p.m." → "one fifty nine PM"
 
 use super::number_to_words;
 
-/// Parse a written time expression to spoken form.
+/// Meridiem spellings, longest first so dotted forms win over bare ones.
+const MERIDIEMS: &[(&str, &str)] = &[
+    ("a.m.", "AM"),
+    ("p.m.", "PM"),
+    ("a.m", "AM"),
+    ("p.m", "PM"),
+    ("am", "AM"),
+    ("pm", "PM"),
+];
+
+/// Time-zone spellings (dotted variants first).
+const TIMEZONES: &[(&str, &str)] = &[
+    ("e.s.t", "EST"),
+    ("est", "EST"),
+    ("p.s.t", "PST"),
+    ("pst", "PST"),
+    ("c.s.t", "CST"),
+    ("cst", "CST"),
+    ("m.s.t", "MST"),
+    ("mst", "MST"),
+    ("g.m.t", "GMT"),
+    ("gmt", "GMT"),
+    ("u.t.c", "UTC"),
+    ("utc", "UTC"),
+];
+
+/// Parse a written time to spoken form.
 pub fn parse(input: &str) -> Option<String> {
-    let trimmed = input.trim();
+    let lower = input.trim().to_lowercase();
 
-    // Split off AM/PM suffix if present
-    let (time_part, period) = extract_period(trimmed);
+    // Peel an optional trailing time zone, then an optional meridiem.
+    let (rest, tz) = strip_suffix(&lower, TIMEZONES);
+    let (core, meridiem) = strip_suffix(rest.trim_end(), MERIDIEMS);
+    let core = core.trim();
 
-    // Must contain a colon
-    if !time_part.contains(':') {
-        return None;
-    }
-
-    let parts: Vec<&str> = time_part.splitn(2, ':').collect();
-    if parts.len() != 2 {
-        return None;
-    }
-
-    let hour_str = parts[0].trim();
-    let min_str = parts[1].trim();
-
-    if !hour_str.chars().all(|c| c.is_ascii_digit()) || hour_str.is_empty() {
-        return None;
-    }
-    if !min_str.chars().all(|c| c.is_ascii_digit()) || min_str.is_empty() {
-        return None;
-    }
-
-    let hour: u32 = hour_str.parse().ok()?;
-    let minute: u32 = min_str.parse().ok()?;
-
-    if hour > 23 || minute > 59 {
-        return None;
-    }
-
-    // Convert 24h to 12h if no period specified and hour > 12
-    let (spoken_hour, inferred_period) = if period.is_none() && hour > 12 {
-        (hour - 12, Some("p m"))
-    } else if period.is_none() && hour == 0 {
-        (12, Some("a m"))
-    } else if period.is_none() && hour == 12 {
-        (12, None)
+    let core_words = if core.contains(':') {
+        // "… o'clock" only when nothing else marks the hour (no meridiem).
+        spell_colon_time(core, meridiem.is_none())?
+    } else if meridiem.is_some() {
+        // Bare hour ("5pm") or dotted ("1.59 p.m.") only reads as a time when
+        // a meridiem anchors it; otherwise it's a plain number/decimal.
+        spell_bare_or_dotted(core)?
     } else {
-        (hour, None)
+        return None;
     };
 
-    let hour_words = number_to_words(spoken_hour as i64);
-
-    let result = if minute == 0 {
-        // "2:00" → "two" or "two p m"
-        hour_words.clone()
-    } else if minute < 10 {
-        // "2:05" → "two oh five"
-        format!("{} oh {}", hour_words, number_to_words(minute as i64))
-    } else {
-        // "2:30" → "two thirty"
-        format!("{} {}", hour_words, number_to_words(minute as i64))
-    };
-
-    // Append period
-    let final_period = period.or(inferred_period);
-    if let Some(p) = final_period {
-        Some(format!("{} {}", result, p))
-    } else {
-        Some(result)
+    let mut result = core_words;
+    if let Some(m) = meridiem {
+        result.push(' ');
+        result.push_str(m);
     }
+    if let Some(z) = tz {
+        result.push(' ');
+        result.push_str(z);
+    }
+    Some(result)
 }
 
-/// Extract AM/PM period from end of string.
-fn extract_period(input: &str) -> (&str, Option<&str>) {
-    let upper = input.to_uppercase();
-    for (suffix, spoken) in &[
-        (" PM", "p m"),
-        (" AM", "a m"),
-        (" P.M.", "p m"),
-        (" A.M.", "a m"),
-        (" P.M", "p m"),
-        (" A.M", "a m"),
-        (" pm", "p m"),
-        (" am", "a m"),
-    ] {
-        if upper.ends_with(&suffix.to_uppercase()) {
-            let time_part = &input[..input.len() - suffix.len()];
-            return (time_part.trim(), Some(spoken));
+/// Strip the longest matching suffix from `input` (case already lowered),
+/// returning the remainder and the mapped spelling.
+fn strip_suffix<'a>(
+    input: &'a str,
+    table: &[(&str, &'static str)],
+) -> (&'a str, Option<&'static str>) {
+    for &(pat, spoken) in table {
+        if let Some(rest) = input.strip_suffix(pat) {
+            return (rest, Some(spoken));
         }
     }
     (input, None)
+}
+
+/// Spell `H:MM` or `H:MM:SS`. `allow_oclock` renders an on-the-hour `H:MM`
+/// as "… o'clock" (false when a meridiem already marks the hour).
+fn spell_colon_time(core: &str, allow_oclock: bool) -> Option<String> {
+    let parts: Vec<&str> = core.split(':').collect();
+    let nums: Vec<u32> = parts
+        .iter()
+        .map(|p| p.trim())
+        .map(|p| {
+            if p.chars().all(|c| c.is_ascii_digit()) && !p.is_empty() {
+                p.parse().ok()
+            } else {
+                None
+            }
+        })
+        .collect::<Option<Vec<u32>>>()?;
+
+    match nums.as_slice() {
+        [hour, minute] => {
+            let (hour, minute) = (*hour, *minute);
+            if hour > 23 || minute > 59 {
+                return None;
+            }
+            Some(spell_hour_minute(hour, minute, allow_oclock))
+        }
+        [hour, minute, second] => {
+            let (hour, minute, second) = (*hour, *minute, *second);
+            if hour > 23 || minute > 59 || second > 59 {
+                return None;
+            }
+            // Verbose reading: "one hour one minute and one second".
+            Some(format!(
+                "{} {} {} {} and {} {}",
+                number_to_words(hour as i64),
+                unit(hour, "hour"),
+                number_to_words(minute as i64),
+                unit(minute, "minute"),
+                number_to_words(second as i64),
+                unit(second, "second"),
+            ))
+        }
+        _ => None,
+    }
+}
+
+/// Spell a bare hour ("5") or a dotted `H.MM` ("1.59"); the caller has already
+/// confirmed a meridiem is present.
+fn spell_bare_or_dotted(core: &str) -> Option<String> {
+    if let Some((h, m)) = core.split_once('.') {
+        let (h, m) = (parse_u32(h)?, parse_u32(m)?);
+        if h > 23 || m > 59 {
+            return None;
+        }
+        return Some(spell_hour_minute(h, m, false));
+    }
+    let hour = parse_u32(core)?;
+    if hour > 23 {
+        return None;
+    }
+    // Bare hour with a meridiem is on the hour.
+    Some(number_to_words(hour as i64))
+}
+
+/// `H:MM` core words. With a meridiem present the on-the-hour form is just the
+/// hour ("one"); otherwise it reads "… o'clock".
+fn spell_hour_minute(hour: u32, minute: u32, allow_oclock: bool) -> String {
+    let hour_words = number_to_words(hour as i64);
+    if minute == 0 {
+        if allow_oclock {
+            format!("{} o'clock", hour_words)
+        } else {
+            hour_words
+        }
+    } else if minute < 10 {
+        format!("{} oh {}", hour_words, number_to_words(minute as i64))
+    } else {
+        format!("{} {}", hour_words, number_to_words(minute as i64))
+    }
+}
+
+fn parse_u32(s: &str) -> Option<u32> {
+    let t = s.trim();
+    if t.is_empty() || !t.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    t.parse().ok()
+}
+
+fn unit(n: u32, singular: &str) -> String {
+    if n == 1 {
+        singular.to_string()
+    } else {
+        format!("{}s", singular)
+    }
 }
 
 #[cfg(test)]
@@ -102,24 +182,58 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_basic_time() {
+    fn test_oclock_and_24h() {
+        assert_eq!(parse("01:00"), Some("one o'clock".to_string()));
+        assert_eq!(parse("23:00"), Some("twenty three o'clock".to_string()));
         assert_eq!(parse("2:30"), Some("two thirty".to_string()));
         assert_eq!(parse("2:05"), Some("two oh five".to_string()));
-        assert_eq!(parse("12:00"), Some("twelve".to_string()));
     }
 
     #[test]
-    fn test_with_period() {
-        assert_eq!(parse("2:30 PM"), Some("two thirty p m".to_string()));
-        assert_eq!(parse("2:00 PM"), Some("two p m".to_string()));
-        assert_eq!(parse("8:15 AM"), Some("eight fifteen a m".to_string()));
+    fn test_meridiem() {
+        assert_eq!(parse("01:00 am"), Some("one AM".to_string()));
+        assert_eq!(parse("01:00 a.m."), Some("one AM".to_string()));
+        assert_eq!(parse("1:59 p.m."), Some("one fifty nine PM".to_string()));
+        assert_eq!(parse("5pm"), Some("five PM".to_string()));
+        assert_eq!(parse("1 a.m."), Some("one AM".to_string()));
+        assert_eq!(parse("1:00a.m."), Some("one AM".to_string()));
     }
 
     #[test]
-    fn test_24h() {
-        assert_eq!(parse("14:00"), Some("two p m".to_string()));
-        assert_eq!(parse("0:00"), Some("twelve a m".to_string()));
-        assert_eq!(parse("23:59"), Some("eleven fifty nine p m".to_string()));
+    fn test_timezone() {
+        assert_eq!(
+            parse("1:59 p.m. est"),
+            Some("one fifty nine PM EST".to_string())
+        );
+        assert_eq!(
+            parse("1:59 p.m.est"),
+            Some("one fifty nine PM EST".to_string())
+        );
+        assert_eq!(
+            parse("1:59 p.m. e.s.t"),
+            Some("one fifty nine PM EST".to_string())
+        );
+    }
+
+    #[test]
+    fn test_dotted_meridiem() {
+        assert_eq!(parse("1.59 p.m."), Some("one fifty nine PM".to_string()));
+    }
+
+    #[test]
+    fn test_hms_verbose() {
+        assert_eq!(
+            parse("1:01:01"),
+            Some("one hour one minute and one second".to_string())
+        );
+        assert_eq!(
+            parse("14:10:30"),
+            Some("fourteen hours ten minutes and thirty seconds".to_string())
+        );
+        assert_eq!(
+            parse("10:00:00 p.m. e.s.t"),
+            Some("ten hours zero minutes and zero seconds PM EST".to_string())
+        );
     }
 
     #[test]
@@ -127,5 +241,6 @@ mod tests {
         assert_eq!(parse("hello"), None);
         assert_eq!(parse("25:00"), None);
         assert_eq!(parse("12:60"), None);
+        assert_eq!(parse("5"), None); // bare number, no meridiem
     }
 }

--- a/swift-test/Sources/NemoTest/NemoTest.swift
+++ b/swift-test/Sources/NemoTest/NemoTest.swift
@@ -264,10 +264,10 @@ let tnMoneyTests: [TC] = [
 let tnTimeTests: [TC] = [
     ("2:30", "two thirty"),
     ("2:05", "two oh five"),
-    ("2:00 PM", "two p m"),
-    ("2:30 PM", "two thirty p m"),
-    ("8:15 AM", "eight fifteen a m"),
-    ("14:00", "two p m"),
+    ("2:00 PM", "two PM"),
+    ("2:30 PM", "two thirty PM"),
+    ("8:15 AM", "eight fifteen AM"),
+    ("14:00", "fourteen o'clock"),
 ]
 
 let tnDateTests: [TC] = [

--- a/tests/data/en/tn_time.txt
+++ b/tests/data/en/tn_time.txt
@@ -1,12 +1,21 @@
-# Time TN: written~spoken
-2:30~two thirty
-2:05~two oh five
-12:00~twelve
-2:30 PM~two thirty p m
-2:00 PM~two p m
-8:15 AM~eight fifteen a m
-14:00~two p m
-0:00~twelve a m
-23:59~eleven fifty nine p m
-11:30~eleven thirty
-9:45~nine forty five
+# English time TN cases (NeMo conventions). 2pm-5pm omitted (range class).
+01:00~one o'clock
+01:00 am~one AM
+01:00 a.m.~one AM
+01:00 a.m~one AM
+1 a.m.~one AM
+23:00~twenty three o'clock
+1:00 a.m.~one AM
+1:00a.m.~one AM
+1.59 p.m.~one fifty nine PM
+01:59 p.m.~one fifty nine PM
+1:59 p.m.~one fifty nine PM
+1:59 p.m. est~one fifty nine PM EST
+1:59 p.m.est~one fifty nine PM EST
+1:59 p.m. e.s.t~one fifty nine PM EST
+10:00:00 p.m. e.s.t~ten hours zero minutes and zero seconds PM EST
+1:01:01~one hour one minute and one second
+14:10:30~fourteen hours ten minutes and thirty seconds
+5pm~five PM
+21:51:31~twenty one hours fifty one minutes and thirty one seconds
+01:01:01~one hour one minute and one second

--- a/tests/extensive_tests.rs
+++ b/tests/extensive_tests.rs
@@ -626,7 +626,7 @@ fn test_tn_money_large_cents() {
 #[test]
 fn test_tn_time_basic() {
     assert_eq!(tn_normalize("2:30"), "two thirty");
-    assert_eq!(tn_normalize("12:00"), "twelve");
+    assert_eq!(tn_normalize("12:00"), "twelve o'clock");
     assert_eq!(tn_normalize("12:15"), "twelve fifteen");
 }
 
@@ -638,19 +638,20 @@ fn test_tn_time_oh_minutes() {
 }
 
 #[test]
-fn test_tn_time_24h_conversion() {
-    assert_eq!(tn_normalize("14:00"), "two p m");
-    assert_eq!(tn_normalize("13:30"), "one thirty p m");
-    assert_eq!(tn_normalize("23:59"), "eleven fifty nine p m");
-    assert_eq!(tn_normalize("0:00"), "twelve a m");
+fn test_tn_time_24h() {
+    // 24-hour clock is kept as-is (NeMo) — no 12h conversion.
+    assert_eq!(tn_normalize("14:00"), "fourteen o'clock");
+    assert_eq!(tn_normalize("13:30"), "thirteen thirty");
+    assert_eq!(tn_normalize("23:59"), "twenty three fifty nine");
+    assert_eq!(tn_normalize("0:00"), "zero o'clock");
 }
 
 #[test]
 fn test_tn_time_with_period() {
-    assert_eq!(tn_normalize("2:30 PM"), "two thirty p m");
-    assert_eq!(tn_normalize("8:15 AM"), "eight fifteen a m");
-    assert_eq!(tn_normalize("2:30 pm"), "two thirty p m");
-    assert_eq!(tn_normalize("2:30 am"), "two thirty a m");
+    assert_eq!(tn_normalize("2:30 PM"), "two thirty PM");
+    assert_eq!(tn_normalize("8:15 AM"), "eight fifteen AM");
+    assert_eq!(tn_normalize("2:30 pm"), "two thirty PM");
+    assert_eq!(tn_normalize("2:30 am"), "two thirty AM");
 }
 
 #[test]
@@ -661,9 +662,8 @@ fn test_tn_time_invalid() {
 
 #[test]
 fn test_tn_time_midnight_noon() {
-    assert_eq!(tn_normalize("12:00"), "twelve");
-    // 0:00 should be midnight (12 AM)
-    assert_eq!(tn_normalize("0:00"), "twelve a m");
+    assert_eq!(tn_normalize("12:00"), "twelve o'clock");
+    assert_eq!(tn_normalize("0:00"), "zero o'clock");
 }
 
 // ════════════════════════════════════════════════════════════════════════

--- a/tests/parity_baseline.tsv
+++ b/tests/parity_baseline.tsv
@@ -65,7 +65,7 @@ en	tn	roman	3	4
 en	tn	serial	0	32
 en	tn	special_text	9	10
 en	tn	telephone	14	20
-en	tn	time	0	21
+en	tn	time	20	21
 en	tn	whitelist	4	7
 en	tn	word	35	39
 es	itn	cardinal	51	51


### PR DESCRIPTION
## TN-gap installment: time → 20/21

English TN `time` was **0/21** vs NeMo — the port used a minimalist reading that matched none of NeMo's cases. Rewritten to NeMo conventions; now **20/21** (only `2pm-5pm`, a cross-class range, is omitted).

| Input | Was | Now |
|-------|-----|-----|
| `01:00` | one | one o'clock |
| `23:00` | eleven p m | twenty three o'clock *(24h kept)* |
| `01:00 am` | one a m | one AM |
| `1:59 p.m. est` | one fifty nine p m est | one fifty nine PM EST |
| `1:01:01` | *(passthrough)* | one hour one minute and one second |
| `1.59 p.m.` | one point five nine p.m. | one fifty nine PM |
| `5pm` | *(passthrough)* | five PM |

### Rules
- **24-hour clock kept as-is** (no 12h conversion).
- **On the hour** → "… o'clock" without a meridiem; bare hour with one.
- **Uppercase** meridiems (AM/PM) and time zones (EST/PST/…); dotted & glued variants (`p.m.`, `p.m.est`, `1:00a.m.`) handled.
- **Verbose `H:MM:SS`** with singular/plural units.
- **Decimal-dot / bare** forms read as time only when a meridiem anchors them (`1.59 p.m.`, `5pm`), so plain numbers/decimals are untouched.

### ⚠️ Behavior change (3 surfaces updated)
Times now read NeMo-style instead of the old minimalist form. Updated the port's own assertions across **Rust** (`lib`, `extensive`), the **Swift FFI harness**, and re-vendored `tests/data/en/tn_time.txt` (20 cases). No WASM time cases. Parity baseline refreshed (`en tn time` 0→20). Full suite green; new code clippy-clean.

For TTS consumers this is a net improvement — "one o'clock" / "two thirty PM" reads correctly, vs the old "one" / "two thirty p m".

Running English TN: cardinal 17/18 · decimal 12/12 · fraction 16/16 · money 64/71 · date 22/54 · **time 20/21** · math 4/4 · ordinal 18/27 · roman 3/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)