### PR TITLE
ci: build & publish NemoTextProcessing.xcframework on release

### DIFF
--- a/.github/workflows/xcframework.yml
+++ b/.github/workflows/xcframework.yml
@@ -1,0 +1,54 @@
+name: XCFramework
+
+# Builds NemoTextProcessing.xcframework (macOS universal + iOS device + iOS
+# simulator) so Apple consumers (e.g. FluidAudio) can link the native FFI via
+# a SwiftPM `.binaryTarget(url:checksum:)` instead of hand-linking the lib.
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  xcframework:
+    name: Build & publish xcframework
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin,aarch64-apple-ios,aarch64-apple-ios-sim
+
+      - name: Build xcframework
+        run: ./build-xcframework.sh
+
+      - name: Package + checksum
+        working-directory: output
+        run: |
+          zip -ry NemoTextProcessing.xcframework.zip NemoTextProcessing.xcframework
+          # SwiftPM binary-target checksum is the SHA-256 of the zip.
+          shasum -a 256 NemoTextProcessing.xcframework.zip | cut -d' ' -f1 \
+            > NemoTextProcessing.xcframework.zip.checksum
+          echo "checksum: $(cat NemoTextProcessing.xcframework.zip.checksum)"
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: NemoTextProcessing-xcframework
+          path: |
+            output/NemoTextProcessing.xcframework.zip
+            output/NemoTextProcessing.xcframework.zip.checksum
+            output/NemoTextProcessing.swift
+
+      - name: Attach to release
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${GITHUB_REF_NAME}" \
+            output/NemoTextProcessing.xcframework.zip \
+            output/NemoTextProcessing.xcframework.zip.checksum \
+            output/NemoTextProcessing.swift --clobber

--- a/.github/workflows/xcframework.yml
+++ b/.github/workflows/xcframework.yml
@@ -6,6 +6,13 @@ name: XCFramework
 on:
   push:
     tags: ["v*"]
+  # Validate the build itself when the workflow or build inputs change; the
+  # release-upload step is tag-gated so PR runs only produce a CI artifact.
+  pull_request:
+    paths:
+      - ".github/workflows/xcframework.yml"
+      - "build-xcframework.sh"
+      - "swift/**"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Why
All the TN work is dormant for Apple consumers (FluidAudio) unless the native `libtext_processing_rs` is linked into the process — currently only via hand-linking. This adds an automated **xcframework** so FluidAudio can consume the FFI through a SwiftPM `.binaryTarget(url:checksum:)`, the prerequisite to enabling the native TN path by default (FluidAudio #784 wired the Swift side but it's inert without the lib).

## What
`.github/workflows/xcframework.yml`:
- Runs `build-xcframework.sh` on a macOS runner (Xcode + the four Apple Rust targets: macOS arm64/x86_64, iOS device, iOS sim) → `NemoTextProcessing.xcframework`.
- Zips it and computes the SwiftPM **SHA-256 checksum**.
- Uploads the zip + checksum + Swift wrapper as a **CI artifact** always, and **attaches them to the GitHub release** on a `v*` tag.

The xcframework includes the full FFI surface — ITN *and* the 6 `nemo_tn_*` TN exports that FluidAudio's `TextNormalizer` dlsym-binds.

## Validation
Triggers: `v*` tags (release upload), `workflow_dispatch`, and — scoped by `paths` — `pull_request` when this workflow or `build-xcframework.sh` changes, so **this PR runs the full build** and produces the artifact without the upload (tag-gated). If the build job is green here, the release path works.

## Next (FluidAudio side, separate)
Once a release carries the xcframework + checksum, FluidAudio adds `.binaryTarget(url:…, checksum:…)` and can drop the dlopen-optional gate to make native TN the default. Not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)