### PR TITLE
feat(tn/en): word dates — abbreviated/cased months + British Day-Month (22 → 40/54)

### DIFF
--- a/src/tn/en/date.rs
+++ b/src/tn/en/date.rs
@@ -8,21 +8,6 @@
 
 use super::number_to_words;
 
-const MONTHS: &[(&str, &str)] = &[
-    ("january", "january"),
-    ("february", "february"),
-    ("march", "march"),
-    ("april", "april"),
-    ("may", "may"),
-    ("june", "june"),
-    ("july", "july"),
-    ("august", "august"),
-    ("september", "september"),
-    ("october", "october"),
-    ("november", "november"),
-    ("december", "december"),
-];
-
 const MONTH_NUMBERS: &[(&str, u32)] = &[
     ("january", 1),
     ("february", 2),
@@ -47,8 +32,9 @@ pub fn parse(input: &str) -> Option<String> {
         return Some(result);
     }
 
-    // Try "Month Day, Year" or "Month Day"
-    if let Some(result) = parse_month_day_year(trimmed) {
+    // Try word dates: "January 5, 2025", "jul 25 2012" (US Month-Day) and
+    // "25 july 2012" (British Day-Month), with abbreviated/cased months.
+    if let Some(result) = parse_word_date(trimmed) {
         return Some(result);
     }
 
@@ -155,81 +141,91 @@ fn parse_decade(input: &str) -> Option<String> {
     }
 }
 
-/// Parse "Month Day, Year" or "Month Day" formats.
-fn parse_month_day_year(input: &str) -> Option<String> {
-    let lower = input.to_lowercase();
-
-    // Find the month
-    let mut month_name = None;
-    let mut rest = "";
-    for &(name, spoken) in MONTHS {
-        if let Some(r) = lower.strip_prefix(name) {
-            if r.is_empty() || r.starts_with(' ') || r.starts_with(',') {
-                month_name = Some(spoken);
-                rest = r.trim_start_matches(|c: char| c == ' ' || c == ',');
-                break;
-            }
-        }
+/// Parse a word date in either order — US `Month Day[, Year]` (`jul 25 2012`
+/// → "july twenty fifth …") or British `Day Month [Year]` (`25 july 2012` →
+/// "the twenty fifth of july …"). Months may be full or 3-letter
+/// abbreviations, any case, with an optional trailing dot.
+fn parse_word_date(input: &str) -> Option<String> {
+    // Commas are separators here; sentence mode re-attaches any real ones.
+    let cleaned = input.replace(',', " ");
+    let tokens: Vec<&str> = cleaned.split_whitespace().collect();
+    if tokens.len() < 2 || tokens.len() > 3 {
+        return None;
     }
-
-    let month = month_name?;
-
-    if rest.is_empty() {
-        return None; // Just a month name alone
-    }
-
-    // Parse day, possibly followed by comma and year
-    let (day_str, year_part) = if let Some(comma_pos) = rest.find(',') {
-        (&rest[..comma_pos], Some(rest[comma_pos + 1..].trim()))
+    let year = if tokens.len() == 3 {
+        Some(parse_year_word(tokens[2])?)
     } else {
-        // Could be "January 5 2025" or "January 5 2025." (space-separated, optional trailing punct)
-        let parts: Vec<&str> = rest.splitn(2, ' ').collect();
-        if parts.len() == 2 && parts[0].chars().all(|c| c.is_ascii_digit()) {
-            let year_clean =
-                parts[1].trim_end_matches(|c: char| c == '.' || c == ',' || c == '!' || c == '?');
-            if year_clean.chars().all(|c| c.is_ascii_digit()) && year_clean.len() == 4 {
-                (parts[0], Some(year_clean))
-            } else {
-                (rest, None)
-            }
-        } else {
-            (rest, None)
-        }
+        None
     };
 
-    let day_str = day_str.trim();
-    // Strip ordinal suffix from day if present (e.g., "5th")
-    let day_digits = day_str
+    // US order: Month Day [Year].
+    if let Some(month) = parse_month(tokens[0]) {
+        let day = parse_day(tokens[1])?;
+        return Some(with_year(format!("{} {}", month, ordinal_word(day)), year));
+    }
+
+    // British order: Day Month [Year].
+    if let Some(day) = parse_day(tokens[0]) {
+        let month = parse_month(tokens[1])?;
+        return Some(with_year(
+            format!("the {} of {}", ordinal_word(day), month),
+            year,
+        ));
+    }
+
+    None
+}
+
+fn with_year(base: String, year: Option<String>) -> String {
+    match year {
+        Some(y) => format!("{} {}", base, y),
+        None => base,
+    }
+}
+
+/// Recognize a month name (full or 3-letter abbreviation, any case, optional
+/// trailing dot) and return its spoken (lower-case) form.
+fn parse_month(token: &str) -> Option<&'static str> {
+    let t = token.trim().trim_end_matches('.').to_lowercase();
+    Some(match t.as_str() {
+        "january" | "jan" => "january",
+        "february" | "feb" => "february",
+        "march" | "mar" => "march",
+        "april" | "apr" => "april",
+        "may" => "may",
+        "june" | "jun" => "june",
+        "july" | "jul" => "july",
+        "august" | "aug" => "august",
+        "september" | "sep" | "sept" => "september",
+        "october" | "oct" => "october",
+        "november" | "nov" => "november",
+        "december" | "dec" => "december",
+        _ => return None,
+    })
+}
+
+/// Parse a day-of-month token, plain or with an ordinal suffix (`25`, `25th`).
+fn parse_day(token: &str) -> Option<u32> {
+    let digits = token
+        .trim()
         .trim_end_matches("st")
         .trim_end_matches("nd")
         .trim_end_matches("rd")
         .trim_end_matches("th");
-
-    if !day_digits.chars().all(|c| c.is_ascii_digit()) || day_digits.is_empty() {
+    if digits.is_empty() || !digits.chars().all(|c| c.is_ascii_digit()) {
         return None;
     }
+    let day: u32 = digits.parse().ok()?;
+    (1..=31).contains(&day).then_some(day)
+}
 
-    let day: u32 = day_digits.parse().ok()?;
-    if day == 0 || day > 31 {
-        return None;
+/// Parse a 4-digit year token (trailing punctuation allowed) year-style.
+fn parse_year_word(token: &str) -> Option<String> {
+    let t = token.trim().trim_end_matches(|c: char| !c.is_ascii_digit());
+    if t.len() == 4 && t.chars().all(|c| c.is_ascii_digit()) {
+        return verbalize_year(t.parse().ok()?);
     }
-
-    let day_ordinal = ordinal_word(day);
-
-    if let Some(year_str) = year_part {
-        // Strip trailing sentence punctuation (e.g. "2026." → "2026") so that
-        // "March 8, 2026." correctly parses the year instead of dropping it.
-        let year_str = year_str
-            .trim()
-            .trim_end_matches(|c: char| c == '.' || c == ',' || c == '!' || c == '?');
-        if !year_str.is_empty() && year_str.chars().all(|c| c.is_ascii_digit()) {
-            let year: u32 = year_str.parse().ok()?;
-            let year_words = verbalize_year(year)?;
-            return Some(format!("{} {} {}", month, day_ordinal, year_words));
-        }
-    }
-
-    Some(format!("{} {}", month, day_ordinal))
+    None
 }
 
 /// Parse numeric date: "1/5/2025" or "01/05/2025" (M/D/Y).
@@ -380,6 +376,39 @@ mod tests {
         assert_eq!(
             parse("December 25"),
             Some("december twenty fifth".to_string())
+        );
+    }
+
+    #[test]
+    fn test_abbreviated_and_cased_months() {
+        assert_eq!(
+            parse("jul 25 2012"),
+            Some("july twenty fifth twenty twelve".to_string())
+        );
+        assert_eq!(parse("SEPT. 15"), Some("september fifteenth".to_string()));
+        assert_eq!(
+            parse("Jan. 15 2020"),
+            Some("january fifteenth twenty twenty".to_string())
+        );
+    }
+
+    #[test]
+    fn test_british_day_month() {
+        assert_eq!(
+            parse("25 july 2012"),
+            Some("the twenty fifth of july twenty twelve".to_string())
+        );
+        assert_eq!(
+            parse("15 january"),
+            Some("the fifteenth of january".to_string())
+        );
+        assert_eq!(
+            parse("16 July 1943"),
+            Some("the sixteenth of july nineteen forty three".to_string())
+        );
+        assert_eq!(
+            parse("25th july 2012"),
+            Some("the twenty fifth of july twenty twelve".to_string())
         );
     }
 

--- a/tests/data/en/tn_date.txt
+++ b/tests/data/en/tn_date.txt
@@ -1,9 +1,17 @@
-# English date TN cases (NeMo conventions).
-# Curated to the cases the port passes; omitted upstream cases need
-# formats not yet implemented: British "the Nth of Month", abbreviated/
-# cased months, numeric YYYY-MM-DD / DD.MM.YYYY, quarters, and sentences.
+# English date TN cases (NeMo), single-expression subset for the asserting
+# test. Numeric dates, quarters, 'AD', spaced-decade, and sentence-context
+# cases are omitted (some pass only in sentence mode; see parity baseline).
 july 25 2012~july twenty fifth twenty twelve
+jul 25 2012~july twenty fifth twenty twelve
 1980s~nineteen eighties
+25 july 2012~the twenty fifth of july twenty twelve
+25 jul 2012~the twenty fifth of july twenty twelve
+22 july 2012~the twenty second of july twenty twelve
+25th july 2012~the twenty fifth of july twenty twelve
+25th jul 2012~the twenty fifth of july twenty twelve
+22nd july 2012~the twenty second of july twenty twelve
+15 january~the fifteenth of january
+17 may 2010~the seventeenth of may twenty ten
 january 1~january first
 june 30~june thirtieth
 2012~twenty twelve
@@ -14,10 +22,19 @@ june 20 2014~june twentieth twenty fourteen
 1975~nineteen seventy five
 1155~eleven fifty five
 august 23 2002~august twenty third two thousand two
+16 July 1943~the sixteenth of july nineteen forty three
+20 january~the twentieth of january
 1980s~nineteen eighties
 10/06/2005~october sixth two thousand five
 1910s~nineteen tens
 2000s~two thousands
+25 sept.~the twenty fifth of september
 1000~one thousand
+SEPT. 15~september fifteenth
+JAN. 15 2020~january fifteenth twenty twenty
+Jan. 15 2020~january fifteenth twenty twenty
+Jan 15 2020~january fifteenth twenty twenty
+jan. 15~january fifteenth
+JAN 15 2020~january fifteenth twenty twenty
 01/07/98~january seventh ninety eight
 '80s~eighties

--- a/tests/parity_baseline.tsv
+++ b/tests/parity_baseline.tsv
@@ -49,7 +49,7 @@ en	itn	word	55	55
 en	itn	word_cased	49	49
 en	tn	address	1	11
 en	tn	cardinal	17	18
-en	tn	date	22	54
+en	tn	date	40	54
 en	tn	decimal	12	12
 en	tn	electronic	1	45
 en	tn	fraction	16	16


### PR DESCRIPTION
## TN-gap installment: date word formats

`date` was 22/54; this adds the word-date families → **40/54**.

| Input | Output |
|-------|--------|
| `jul 25 2012` | july twenty fifth twenty twelve |
| `SEPT. 15` | september fifteenth |
| `Jan. 15 2020` | january fifteenth twenty twenty |
| `25 july 2012` | the twenty fifth of july twenty twelve |
| `15 january` | the fifteenth of january |
| `16 July 1943` | the sixteenth of july nineteen forty three |
| `25th july 2012` | the twenty fifth of july twenty twelve |

### What changed
`parse_word_date` replaces the old month-first-only parser and handles **both orders** plus **abbreviated/cased months**:
- **US** `Month Day[, Year]` and **British** `Day Month [Year]`.
- Months: full or 3-letter abbreviation, any case, optional trailing dot.
- Days: plain or ordinal (`25`/`25th`); years read year-style via `verbalize_year`.
- The previously-handled US full-month cases (`January 5, 2025`) still pass through the same path.

### Left for a follow-up
Numeric dates (`YYYY-MM-DD`, `DD.MM.YYYY`, `MM/DD/YY`), quarters (`2Q22`), `AD`/`BC`, and spaced-decade (`1980 s`).

### Tests
Re-vendors `tests/data/en/tn_date.txt` (37 single-expression cases for the asserting test; the parity baseline tracks 40 in sentence mode), adds unit coverage. Full suite green; new code clippy-clean.

Running English TN: cardinal 17/18 · decimal 12/12 · fraction 16/16 · money 64/71 · **date 40/54** · time 20/21 · measure 5/21 · math 4/4 · ordinal 18/27 · roman 3/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)