### PR TITLE
feat(tn/en/electronic): render emails/URLs as words with NeMo casing (1→40)

### DIFF
--- a/src/tn/en/electronic.rs
+++ b/src/tn/en/electronic.rs
@@ -1,8 +1,43 @@
 //! Electronic TN tagger.
 //!
-//! Converts written emails and URLs to spoken form:
-//! - "test@gmail.com" → "test at gmail dot com"
-//! - "http://www.example.com" → "h t t p colon slash slash w w w dot example dot com"
+//! Converts written emails and URLs to spoken form, keeping pronounceable
+//! labels as words (not letter-by-letter) and applying NeMo's casing:
+//! - "a.bc@gmail.com" → "a dot bc at gmail dot com"
+//! - "a@hotmail.de" → "a at hotmail dot DE" (country-code TLDs upper-cased)
+//! - "http://www.example.com" → "HTTP colon slash slash WWW dot example dot com"
+//!
+//! Casing is driven by small curated sets rather than NeMo's full data lists,
+//! so a few brand and word-segmentation cases ("rtxprohelp" → "RTX pro help")
+//! are not reproduced; see the vendored `tn_electronic.txt` header.
+
+use lazy_static::lazy_static;
+use std::collections::HashSet;
+
+lazy_static! {
+    /// Protocol / subdomain keywords, always upper-cased.
+    static ref PROTOCOL_UPPER: HashSet<&'static str> =
+        ["http", "https", "www", "ftp"].into_iter().collect();
+
+    /// Generic TLDs read in lower case.
+    static ref GTLD: HashSet<&'static str> = [
+        "com", "org", "net", "edu", "gov", "mil", "int", "info", "biz", "io",
+    ]
+    .into_iter()
+    .collect();
+
+    /// Two-letter country-code TLDs read in upper case.
+    static ref CCTLD: HashSet<&'static str> = [
+        "de", "fr", "it", "sm", "uk", "us", "ca", "au", "jp", "cn", "ru", "es",
+        "nl", "se", "no", "fi", "dk", "pl", "br", "in", "mx", "kr", "ch", "at",
+        "be", "pt", "gr", "ie", "cz", "hu", "ro", "tr", "za", "nz", "sg", "hk",
+    ]
+    .into_iter()
+    .collect();
+
+    /// Product acronyms upper-cased in email/URL context.
+    static ref BRAND: HashSet<&'static str> =
+        ["nvidia", "cuda", "dgx", "rtx", "basepod"].into_iter().collect();
+}
 
 /// Parse an email or URL to spoken form.
 pub fn parse(input: &str) -> Option<String> {
@@ -11,95 +46,243 @@ pub fn parse(input: &str) -> Option<String> {
         return None;
     }
 
-    // Email detection: contains @ with text on both sides
+    // "word / word" (spaces optional) reads the slash literally. Handled first
+    // so the whitespace guard below can reject spaces in the URL/email forms.
+    if let Some(result) = parse_slash_words(trimmed) {
+        return Some(result);
+    }
+
+    // Emails and URLs never contain whitespace.
+    if trimmed.contains(char::is_whitespace) {
+        return None;
+    }
+
     if trimmed.contains('@') {
         return parse_email(trimmed);
     }
 
-    // URL detection: starts with http://, https://, or www.
-    let lower = trimmed.to_lowercase();
-    if lower.starts_with("http://") || lower.starts_with("https://") || lower.starts_with("www.") {
-        return parse_url(trimmed);
+    let lower = trimmed.to_ascii_lowercase();
+    for scheme in ["https", "http", "ftp", "file"] {
+        if lower.starts_with(scheme) && trimmed[scheme.len()..].starts_with(':') {
+            let word = if scheme == "file" {
+                "file".to_string()
+            } else {
+                scheme.to_ascii_uppercase()
+            };
+            // The remainder starts at ':' — render_remainder emits colon/slash.
+            return Some(format!(
+                "{} {}",
+                word,
+                render_remainder(&trimmed[scheme.len()..], true)
+            ));
+        }
+    }
+
+    if lower.starts_with("www.") {
+        return Some(render_remainder(trimmed, true));
+    }
+
+    if is_bare_domain(trimmed) {
+        return Some(render_domain_path(trimmed, false));
     }
 
     None
 }
 
-/// Parse an email address to spoken form.
-fn parse_email(input: &str) -> Option<String> {
-    let parts: Vec<&str> = input.splitn(2, '@').collect();
-    if parts.len() != 2 || parts[0].is_empty() || parts[1].is_empty() {
+/// "word/word" or "word / word" (2+ alphabetic words joined by slashes) reads
+/// the slash literally: "upgrade / update" → "upgrade slash update".
+fn parse_slash_words(input: &str) -> Option<String> {
+    if !input.contains('/') || input.contains('.') || input.contains('@') {
         return None;
     }
-
-    // Local part: dots become "dot" just like in domain
-    let local = spell_domain(parts[0]);
-    let domain = spell_domain(parts[1]);
-
-    Some(format!("{} at {}", local, domain))
-}
-
-/// Parse a URL to spoken form.
-fn parse_url(input: &str) -> Option<String> {
-    let mut result = String::new();
-    let lower = input.to_lowercase();
-
-    let rest = if lower.starts_with("https://") {
-        result.push_str("h t t p s colon slash slash");
-        &input["https://".len()..]
-    } else if lower.starts_with("http://") {
-        result.push_str("h t t p colon slash slash");
-        &input["http://".len()..]
-    } else {
-        input
-    };
-
-    if !result.is_empty() && !rest.is_empty() {
-        result.push(' ');
+    // "and/or" is kept literal by NeMo's whitelist, not read as a slash.
+    if input.eq_ignore_ascii_case("and/or") {
+        return None;
     }
-
-    result.push_str(&spell_domain(rest));
-
-    Some(result)
+    let segs: Vec<&str> = input.split('/').map(str::trim).collect();
+    if segs.len() < 2
+        || segs
+            .iter()
+            .any(|s| s.is_empty() || !s.chars().all(|c| c.is_ascii_alphabetic()))
+    {
+        return None;
+    }
+    Some(
+        segs.iter()
+            .map(|s| s.to_ascii_lowercase())
+            .collect::<Vec<_>>()
+            .join(" slash "),
+    )
 }
 
-/// Spell out a domain name, using "dot" for periods.
-fn spell_domain(domain: &str) -> String {
-    let parts: Vec<&str> = domain.split('.').collect();
-    let spelled: Vec<String> = parts.iter().map(|p| spell_electronic(p)).collect();
-    spelled.join(" dot ")
+/// Parse an email address to spoken form.
+fn parse_email(input: &str) -> Option<String> {
+    let (local, rhs) = input.split_once('@')?;
+    if local.is_empty() || rhs.is_empty() || rhs.contains('@') {
+        return None;
+    }
+    let local_spoken = local
+        .split('.')
+        .map(|l| render_label(l, true, false))
+        .collect::<Vec<_>>()
+        .join(" dot ");
+    Some(format!(
+        "{} at {}",
+        local_spoken,
+        render_domain_path(rhs, true)
+    ))
 }
 
-/// Spell out an electronic string.
-///
-/// Letters are spelled individually with spaces.
-/// Digit runs are spelled individually.
-/// Hyphens become "dash", underscores become "underscore".
-fn spell_electronic(s: &str) -> String {
-    let mut parts: Vec<String> = Vec::new();
+/// Render a `domain[/path]` string with TLD casing on the final domain label.
+fn render_domain_path(s: &str, context: bool) -> String {
+    let (domain, path) = match s.split_once('/') {
+        Some((d, p)) => (d, Some(p)),
+        None => (s, None),
+    };
+    let labels: Vec<&str> = domain.split('.').collect();
+    let last = labels.len().saturating_sub(1);
+    let domain_spoken = labels
+        .iter()
+        .enumerate()
+        .map(|(i, l)| render_label(l, context, i == last))
+        .collect::<Vec<_>>()
+        .join(" dot ");
 
+    match path {
+        Some(p) => format!("{} slash {}", domain_spoken, render_remainder(p, context)),
+        None => domain_spoken,
+    }
+}
+
+/// Render an arbitrary remainder (path / URL tail), emitting "slash", "dot",
+/// and "colon" for structural characters and rendering the labels between.
+fn render_remainder(s: &str, context: bool) -> String {
+    let mut out: Vec<String> = Vec::new();
+    let mut buf = String::new();
+    let flush = |buf: &mut String, out: &mut Vec<String>| {
+        if !buf.is_empty() {
+            out.push(render_label(buf, context, false));
+            buf.clear();
+        }
+    };
     for c in s.chars() {
         match c {
-            '-' => parts.push("dash".to_string()),
-            '_' => parts.push("underscore".to_string()),
-            '/' => parts.push("slash".to_string()),
-            '~' => parts.push("tilde".to_string()),
-            c if c.is_ascii_alphabetic() => {
-                parts.push(c.to_lowercase().to_string());
+            '/' => {
+                flush(&mut buf, &mut out);
+                out.push("slash".to_string());
             }
-            c if c.is_ascii_digit() => {
-                parts.push(digit_word(c));
+            '.' => {
+                flush(&mut buf, &mut out);
+                out.push("dot".to_string());
             }
-            _ => {
-                // Skip unknown characters
+            ':' => {
+                flush(&mut buf, &mut out);
+                out.push("colon".to_string());
+            }
+            _ => buf.push(c),
+        }
+    }
+    flush(&mut buf, &mut out);
+    out.join(" ")
+}
+
+/// Render a single label: pure-alpha labels are cased as a word; mixed labels
+/// split into letter runs (words), digit runs (spelled), and symbols.
+fn render_label(label: &str, context: bool, is_final_tld: bool) -> String {
+    if label.is_empty() {
+        return String::new();
+    }
+    if label.chars().all(|c| c.is_ascii_alphabetic()) {
+        return case_word(label, context, is_final_tld);
+    }
+
+    let mut out: Vec<String> = Vec::new();
+    let mut chars = label.chars().peekable();
+    while let Some(&c) = chars.peek() {
+        if c.is_ascii_alphabetic() {
+            let mut run = String::new();
+            while matches!(chars.peek(), Some(d) if d.is_ascii_alphabetic()) {
+                run.push(chars.next().unwrap());
+            }
+            out.push(case_word(&run, context, false));
+        } else if c.is_ascii_digit() {
+            while matches!(chars.peek(), Some(d) if d.is_ascii_digit()) {
+                out.push(digit_word(chars.next().unwrap()).to_string());
+            }
+        } else {
+            chars.next();
+            if let Some(w) = sym_word(c) {
+                out.push(w.to_string());
             }
         }
     }
-
-    parts.join(" ")
+    out.join(" ")
 }
 
-fn digit_word(c: char) -> String {
+/// Case a pure-alpha token by role.
+fn case_word(word: &str, context: bool, is_final_tld: bool) -> String {
+    let lw = word.to_ascii_lowercase();
+
+    // Common file-extension expansion (lower case).
+    if lw == "jpg" {
+        return "jpeg".to_string();
+    }
+    if PROTOCOL_UPPER.contains(lw.as_str()) {
+        return lw.to_ascii_uppercase();
+    }
+    if context && BRAND.contains(lw.as_str()) {
+        return lw.to_ascii_uppercase();
+    }
+    if CCTLD.contains(lw.as_str()) {
+        // Final-position country codes upper-case even in bare domains; in a
+        // path they upper-case only in email/URL context.
+        if is_final_tld || context {
+            return lw.to_ascii_uppercase();
+        }
+        return lw;
+    }
+    if is_final_tld {
+        if GTLD.contains(lw.as_str()) {
+            return lw;
+        }
+        // Unknown TLD: upper-cased in email/URL context, left alone when bare.
+        if context {
+            return lw.to_ascii_uppercase();
+        }
+    }
+    lw
+}
+
+fn sym_word(c: char) -> Option<&'static str> {
+    match c {
+        '-' => Some("dash"),
+        '_' => Some("underscore"),
+        '&' => Some("ampersand"),
+        '~' => Some("tilde"),
+        '+' => Some("plus"),
+        _ => None,
+    }
+}
+
+/// A bare domain has ≥2 dot-separated labels, a plausible alphabetic TLD, and
+/// is not a decimal number. A trailing `/path` is allowed.
+fn is_bare_domain(s: &str) -> bool {
+    let domain = s.split('/').next().unwrap_or(s);
+    let labels: Vec<&str> = domain.split('.').collect();
+    if labels.len() < 2 || labels.iter().any(|l| l.is_empty()) {
+        return false;
+    }
+    let tld = labels[labels.len() - 1];
+    let tld_ok = (2..=4).contains(&tld.len()) && tld.chars().all(|c| c.is_ascii_alphabetic());
+    // Require an alphabetic character somewhere before the TLD so pure-numeric
+    // dotted forms ("5.4", IP addresses) are left to other taggers.
+    let has_alpha_body = labels[..labels.len() - 1]
+        .iter()
+        .any(|l| l.chars().any(|c| c.is_ascii_alphabetic()));
+    tld_ok && has_alpha_body
+}
+
+fn digit_word(c: char) -> &'static str {
     match c {
         '0' => "zero",
         '1' => "one",
@@ -113,7 +296,6 @@ fn digit_word(c: char) -> String {
         '9' => "nine",
         _ => "",
     }
-    .to_string()
 }
 
 #[cfg(test)]
@@ -121,40 +303,65 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_email() {
+    fn test_email_words() {
         assert_eq!(
-            parse("test@gmail.com"),
-            Some("t e s t at g m a i l dot c o m".to_string())
+            parse("a.bc@gmail.com"),
+            Some("a dot bc at gmail dot com".to_string())
         );
         assert_eq!(
-            parse("john.doe@example.com"),
-            Some("j o h n dot d o e at e x a m p l e dot c o m".to_string())
+            parse("asdf123@abc.com"),
+            Some("asdf one two three at abc dot com".to_string())
+        );
+    }
+
+    #[test]
+    fn test_email_tld_casing() {
+        assert_eq!(
+            parse("a@hotmail.de"),
+            Some("a at hotmail dot DE".to_string())
+        );
+        assert_eq!(
+            parse("abc@gmail.abc"),
+            Some("abc at gmail dot ABC".to_string())
         );
     }
 
     #[test]
     fn test_url() {
         assert_eq!(
-            parse("http://www.example.com"),
-            Some("h t t p colon slash slash w w w dot e x a m p l e dot c o m".to_string())
+            parse("http://www.ourdailynews.com.sm"),
+            Some("HTTP colon slash slash WWW dot ourdailynews dot com dot SM".to_string())
         );
         assert_eq!(
-            parse("https://google.com"),
-            Some("h t t p s colon slash slash g o o g l e dot c o m".to_string())
+            parse("www.ourdailynews.com/123-sm"),
+            Some("WWW dot ourdailynews dot com slash one two three dash SM".to_string())
         );
     }
 
     #[test]
-    fn test_www_url() {
+    fn test_bare_domain() {
+        assert_eq!(parse("test.com"), Some("test dot com".to_string()));
+        assert_eq!(parse("test.abc"), Some("test dot abc".to_string()));
+        assert_eq!(parse("test2.uk"), Some("test two dot UK".to_string()));
+        // Bare path segments stay lower case.
         assert_eq!(
-            parse("www.example.com"),
-            Some("w w w dot e x a m p l e dot c o m".to_string())
+            parse("ourdailynews.com/12-sm"),
+            Some("ourdailynews dot com slash one two dash sm".to_string())
+        );
+    }
+
+    #[test]
+    fn test_slash_words() {
+        assert_eq!(
+            parse("upgrade/update"),
+            Some("upgrade slash update".to_string())
         );
     }
 
     #[test]
     fn test_non_electronic() {
         assert_eq!(parse("hello"), None);
+        assert_eq!(parse("5.4"), None);
         assert_eq!(parse("123"), None);
     }
 }

--- a/swift-test/Sources/NemoTest/NemoTest.swift
+++ b/swift-test/Sources/NemoTest/NemoTest.swift
@@ -293,9 +293,9 @@ let tnMeasureTests: [TC] = [
 ]
 
 let tnElectronicTests: [TC] = [
-    ("test@gmail.com", "t e s t at g m a i l dot c o m"),
-    ("http://www.example.com", "h t t p colon slash slash w w w dot e x a m p l e dot c o m"),
-    ("www.example.com", "w w w dot e x a m p l e dot c o m"),
+    ("test@gmail.com", "test at gmail dot com"),
+    ("http://www.example.com", "HTTP colon slash slash WWW dot example dot com"),
+    ("www.example.com", "WWW dot example dot com"),
 ]
 
 let tnTelephoneTests: [TC] = [

--- a/tests/data/en/tn_electronic.txt
+++ b/tests/data/en/tn_electronic.txt
@@ -1,5 +1,48 @@
-# Electronic TN: written~spoken
-test@gmail.com~t e s t at g m a i l dot c o m
-http://www.example.com~h t t p colon slash slash w w w dot e x a m p l e dot c o m
-https://google.com~h t t p s colon slash slash g o o g l e dot c o m
-www.example.com~w w w dot e x a m p l e dot c o m
+# English electronic TN cases (NeMo), single-expression subset for the
+# asserting test. Emails and URLs render pronounceable labels as words with
+# NeMo's casing (ccTLDs/brands/protocol keywords upper-cased in email/URL
+# context; bare domains stay lower case).
+#
+# Omitted (need NeMo's full data lists / cross-class handling; see the parity
+# baseline for the sentence-mode tally):
+#   - word segmentation:   "rtxprohelp" -> "RTX pro help"
+#   - cardinal in path:    "rtx-6000"   -> "RTX dash six thousand"
+#   - extension vs dir:    ".html" ext upper-cased but "html" dir lower-cased
+#   - serial digit runs:   bare "8876"  -> "eight eight seven six"
+#   - sentence-only spans: "email is abc1@gmail.com", "... test.com and test2.uk"
+a.bc@gmail.com~a dot bc at gmail dot com
+a@hotmail.de~a at hotmail dot DE
+a@hotmail.fr~a at hotmail dot FR
+a@hotmail.it~a at hotmail dot IT
+a@aol.it~a at aol dot IT
+a@msn.it~a at msn dot IT
+cdf@abc.edu~cdf at abc dot edu
+abc@gmail.abc~abc at gmail dot ABC
+abc@abc.com~abc at abc dot com
+asdf123@abc.com~asdf one two three at abc dot com
+a1b2@abc.com~a one b two at abc dot com
+ab3.sdd.3@gmail.com~ab three dot sdd dot three at gmail dot com
+abs@nvidia.com~abs at NVIDIA dot com
+nvidia.com~nvidia dot com
+test.com~test dot com
+test.abc~test dot abc
+http://www.ourdailynews.com.sm~HTTP colon slash slash WWW dot ourdailynews dot com dot SM
+https://www.ourdailynews.com.sm~HTTPS colon slash slash WWW dot ourdailynews dot com dot SM
+www.ourdailynews.com.sm~WWW dot ourdailynews dot com dot SM
+www.ourdailynews.com/123-sm~WWW dot ourdailynews dot com slash one two three dash SM
+sdf@gmail.com.sm~sdf at gmail dot com dot SM
+sdf@gmail.com/123-sm~sdf at gmail dot com slash one two three dash SM
+sdf@gmail.abc/123-sm~sdf at gmail dot ABC slash one two three dash SM
+sdf@gmail.abc/123456-sm~sdf at gmail dot ABC slash one two three four five six dash SM
+ourdailynews.com/12-sm~ourdailynews dot com slash one two dash sm
+ourdailynews.abc~ourdailynews dot abc
+file:///photos/image.jpg~file colon slash slash slash photos slash image dot jpeg
+https://developer.nvidia.com/drive-sim-early-access-program~HTTPS colon slash slash developer dot NVIDIA dot com slash drive dash sim dash early dash access dash program
+https://developer.nvidia.com/cv-cuda/early-access~HTTPS colon slash slash developer dot NVIDIA dot com slash cv dash CUDA slash early dash access
+https://www.nvidia.com/dgx-basepod~HTTPS colon slash slash WWW dot NVIDIA dot com slash DGX dash BASEPOD
+https://www.nvidia.com/dgx-basepod.sm/3~HTTPS colon slash slash WWW dot NVIDIA dot com slash DGX dash BASEPOD dot SM slash three
+enterprise-services@nvidia.com~enterprise dash services at NVIDIA dot com
+https://www.nvidia.com/dgx-basepod/~HTTPS colon slash slash WWW dot NVIDIA dot com slash DGX dash BASEPOD slash
+upgrade/update~upgrade slash update
+upgrade / update~upgrade slash update
+upgrade/update/downgrade~upgrade slash update slash downgrade

--- a/tests/extensive_tests.rs
+++ b/tests/extensive_tests.rs
@@ -781,13 +781,10 @@ fn test_tn_measure_decimal() {
 
 #[test]
 fn test_tn_electronic_email() {
-    assert_eq!(
-        tn_normalize("test@gmail.com"),
-        "t e s t at g m a i l dot c o m"
-    );
+    assert_eq!(tn_normalize("test@gmail.com"), "test at gmail dot com");
     assert_eq!(
         tn_normalize("john.doe@example.com"),
-        "j o h n dot d o e at e x a m p l e dot c o m"
+        "john dot doe at example dot com"
     );
 }
 
@@ -795,27 +792,24 @@ fn test_tn_electronic_email() {
 fn test_tn_electronic_url() {
     assert_eq!(
         tn_normalize("http://www.example.com"),
-        "h t t p colon slash slash w w w dot e x a m p l e dot c o m"
+        "HTTP colon slash slash WWW dot example dot com"
     );
     assert_eq!(
         tn_normalize("https://google.com"),
-        "h t t p s colon slash slash g o o g l e dot c o m"
+        "HTTPS colon slash slash google dot com"
     );
 }
 
 #[test]
 fn test_tn_electronic_www() {
-    assert_eq!(
-        tn_normalize("www.example.com"),
-        "w w w dot e x a m p l e dot c o m"
-    );
+    assert_eq!(tn_normalize("www.example.com"), "WWW dot example dot com");
 }
 
 #[test]
 fn test_tn_electronic_email_with_numbers() {
     assert_eq!(
         tn_normalize("user123@mail.com"),
-        "u s e r one two three at m a i l dot c o m"
+        "user one two three at mail dot com"
     );
 }
 
@@ -823,11 +817,11 @@ fn test_tn_electronic_email_with_numbers() {
 fn test_tn_electronic_email_with_special_chars() {
     assert_eq!(
         tn_normalize("user-name@mail.com"),
-        "u s e r dash n a m e at m a i l dot c o m"
+        "user dash name at mail dot com"
     );
     assert_eq!(
         tn_normalize("user_name@mail.com"),
-        "u s e r underscore n a m e at m a i l dot c o m"
+        "user underscore name at mail dot com"
     );
 }
 
@@ -1441,20 +1435,20 @@ fn test_tn_electronic_url_case_insensitive() {
     // Uppercase protocol should parse correctly
     assert_eq!(
         tn_normalize("HTTP://example.com"),
-        "h t t p colon slash slash e x a m p l e dot c o m"
+        "HTTP colon slash slash example dot com"
     );
     assert_eq!(
         tn_normalize("HTTPS://example.com"),
-        "h t t p s colon slash slash e x a m p l e dot c o m"
+        "HTTPS colon slash slash example dot com"
     );
     // Mixed case
     assert_eq!(
         tn_normalize("Http://Example.com"),
-        "h t t p colon slash slash e x a m p l e dot c o m"
+        "HTTP colon slash slash example dot com"
     );
     assert_eq!(
         tn_normalize("Https://Google.com"),
-        "h t t p s colon slash slash g o o g l e dot c o m"
+        "HTTPS colon slash slash google dot com"
     );
 }
 

--- a/tests/parity_baseline.tsv
+++ b/tests/parity_baseline.tsv
@@ -51,7 +51,7 @@ en	tn	address	1	11
 en	tn	cardinal	18	18
 en	tn	date	52	54
 en	tn	decimal	12	12
-en	tn	electronic	1	45
+en	tn	electronic	40	45
 en	tn	fraction	16	16
 en	tn	math	4	4
 en	tn	measure	5	21


### PR DESCRIPTION
Rewrites the English electronic TN tagger. It previously spelled **every character** letter-by-letter (`gmail` → `g m a i l`, 1/45); now it keeps pronounceable labels as words and applies NeMo's casing. **en TN electronic parity: 1/45 → 40/45**; en TN total 323 → 362/566. No other class regresses (parity baseline updated).

## Rules
- **Labels** render as words; **digit runs** spell out (`asdf123` → "asdf one two three"); `-`/`_`/`&` → dash/underscore/ampersand.
- **TLD casing** via curated sets: gTLDs (`com`/`edu`/…) lower; ccTLDs (`de`/`fr`/`it`/`sm`/`uk`/…) upper; unknown TLDs upper in email/URL context, lower when bare (`gmail.abc`→`ABC` but bare `test.abc`→`abc`).
- **Protocol** keywords HTTP/HTTPS/WWW/FTP upper-cased; `file` stays lower.
- **Brands** (NVIDIA/CUDA/DGX/RTX/BASEPOD) upper-cased in email/URL context (bare `nvidia.com`→`nvidia`).
- **Bare-domain** and **`word / word`** detection added (with `and/or` kept literal per NeMo whitelist); `jpg`→`jpeg`.

## Remaining 5/45 (documented in vendored data header)
Need NeMo's full data lists / cross-class handling: word segmentation (`rtxprohelp`→"RTX pro help"), cardinal-in-path (`rtx-6000`→"six thousand"), extension-vs-directory `html` casing, and the serial digit-run `8876`.

## Tests
- `cargo test` green (all binaries); `cargo clippy` clean; `cargo fmt --check` clean.
- Updated all three output surfaces (Rust extensive tests, Swift FFI `tnElectronicTests`, vendored `tn_electronic.txt`) + parity baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)