### PR TITLE
feat(tn/en/electronic): read IPv4 addresses as digit-by-digit dots (telephone 14→17)

### DIFF
--- a/src/tn/en/electronic.rs
+++ b/src/tn/en/electronic.rs
@@ -57,6 +57,11 @@ pub fn parse(input: &str) -> Option<String> {
         return None;
     }
 
+    // IPv4 address: four numeric groups read digit-by-digit, joined by "dot".
+    if let Some(ip) = parse_ipv4(trimmed) {
+        return Some(ip);
+    }
+
     if trimmed.contains('@') {
         return parse_email(trimmed);
     }
@@ -112,6 +117,29 @@ fn parse_slash_words(input: &str) -> Option<String> {
             .map(|s| s.to_ascii_lowercase())
             .collect::<Vec<_>>()
             .join(" slash "),
+    )
+}
+
+/// Read a dotted IPv4 address ("123.123.0.40") as four digit-by-digit groups
+/// joined by "dot". Requires exactly four numeric groups so decimals ("5.4")
+/// and version strings are left to other taggers.
+fn parse_ipv4(s: &str) -> Option<String> {
+    let groups: Vec<&str> = s.split('.').collect();
+    if groups.len() != 4 {
+        return None;
+    }
+    if !groups
+        .iter()
+        .all(|g| (1..=3).contains(&g.len()) && g.chars().all(|c| c.is_ascii_digit()))
+    {
+        return None;
+    }
+    Some(
+        groups
+            .iter()
+            .map(|g| g.chars().map(digit_word).collect::<Vec<_>>().join(" "))
+            .collect::<Vec<_>>()
+            .join(" dot "),
     )
 }
 
@@ -348,6 +376,16 @@ mod tests {
             parse("ourdailynews.com/12-sm"),
             Some("ourdailynews dot com slash one two dash sm".to_string())
         );
+    }
+
+    #[test]
+    fn test_ipv4() {
+        assert_eq!(
+            parse("123.123.0.40"),
+            Some("one two three dot one two three dot zero dot four zero".to_string())
+        );
+        // Two-group decimals are not IPs.
+        assert_eq!(parse("5.4"), None);
     }
 
     #[test]

--- a/tests/data/en/tn_telephone.txt
+++ b/tests/data/en/tn_telephone.txt
@@ -3,3 +3,6 @@
 +1-234-567-8901~plus one, two three four, five six seven, eight nine zero one
 (555) 123-4567~five five five, one two three, four five six seven
 555.123.4567~five five five, one two three, four five six seven
+# IPv4 (four numeric groups) reads digit-by-digit joined by "dot".
+987.987.0.40~nine eight seven dot nine eight seven dot zero dot four zero
+123.123.0.40~one two three dot one two three dot zero dot four zero

--- a/tests/parity_baseline.tsv
+++ b/tests/parity_baseline.tsv
@@ -64,7 +64,7 @@ en	tn	range	18	20
 en	tn	roman	3	4
 en	tn	serial	0	32
 en	tn	special_text	9	10
-en	tn	telephone	14	20
+en	tn	telephone	17	20
 en	tn	time	21	21
 en	tn	whitelist	4	7
 en	tn	word	35	39


### PR DESCRIPTION
Adds IPv4 handling to the electronic tagger (electronic runs above telephone in span priority, and dotted IPs are the numeric sibling of domains): four numeric dot-separated groups read digit-by-digit joined by "dot".

- `123.123.0.40` → "one two three dot one two three dot zero dot four zero"
- `987.987.0.40` → "nine eight seven dot nine eight seven dot zero dot four zero"

Requires **exactly four** numeric groups, so decimals (`5.4`), version strings, and the 3-group dotted phone `555.123.4567` fall through unchanged.

**en TN telephone parity: 14/20 → 17/20**; no other class regresses (parity baseline updated).

## Tests
- `cargo test` green; `cargo clippy` clean on the touched file; `cargo fmt --check` clean.
- Added a `parse_ipv4` unit test + vendored telephone cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)