### PR TITLE
feat(tn): fold double-backtick quotes so quoted content normalizes (punctuation 25→32)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1054,8 +1054,15 @@ struct Pretoken {
 fn is_split_punct(c: char) -> bool {
     matches!(
         c,
-        ',' | '.' | ';' | ':' | '!' | '?' | '(' | ')' | '[' | ']' | '{' | '}' | '"'
+        ',' | '.' | ';' | ':' | '!' | '?' | '(' | ')' | '[' | ']' | '{' | '}' | '"' | '`'
     )
+}
+
+/// Fold NeMo's double-backtick quotes to a straight double quote so the
+/// pretokenizer splits them off and the quoted content still normalizes
+/// (`` ``cat`` `` → `"cat"`). TN sentence mode only.
+fn unify_tn_quotes(input: &str) -> String {
+    input.replace("``", "\"")
 }
 
 /// Split each whitespace-separated word into leading punctuation, core, and
@@ -1391,7 +1398,8 @@ pub fn tn_normalize_sentence_with_max_span_lang(
                 return trimmed.to_string();
             }
 
-            let pretokens = pretokenize(trimmed);
+            let unified = unify_tn_quotes(trimmed);
+            let pretokens = pretokenize(&unified);
             sentence_loop(&pretokens, max_span_tokens, |span| {
                 tn_parse_span_lang(span, lang)
             })
@@ -1406,7 +1414,8 @@ pub fn tn_normalize_sentence_with_max_span(input: &str, max_span_tokens: usize) 
         return trimmed.to_string();
     }
 
-    let pretokens = pretokenize(trimmed);
+    let unified = unify_tn_quotes(trimmed);
+    let pretokens = pretokenize(&unified);
     sentence_loop(&pretokens, max_span_tokens, tn_parse_span)
 }
 

--- a/tests/extensive_tests.rs
+++ b/tests/extensive_tests.rs
@@ -1453,6 +1453,30 @@ fn test_tn_electronic_url_case_insensitive() {
 }
 
 // ════════════════════════════════════════════════════════════════════════
+// 26b. TN BACKTICK QUOTE UNIFICATION (punctuation)
+// ════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_tn_sentence_backtick_quotes() {
+    // NeMo double-backtick quotes fold to straight quotes, and the quoted
+    // content still normalizes.
+    assert_eq!(tn_normalize_sentence("``test``."), "\"test\".");
+    assert_eq!(
+        tn_normalize_sentence("animals: ``cat``, ``dog``"),
+        "animals: \"cat\", \"dog\""
+    );
+    assert_eq!(
+        tn_normalize_sentence("``He's 50 and 2010``."),
+        "\"He's fifty and twenty ten\"."
+    );
+    // Single backticks are split off but preserved; content normalizes.
+    assert_eq!(
+        tn_normalize_sentence("a `25` example"),
+        "a `twenty five` example"
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════
 // 27. BUG FIX: i64::MIN OVERFLOW IN number_to_words
 // ════════════════════════════════════════════════════════════════════════
 

--- a/tests/parity_baseline.tsv
+++ b/tests/parity_baseline.tsv
@@ -58,8 +58,8 @@ en	tn	measure	10	21
 en	tn	money	65	71
 en	tn	normalize_with_audio	0	58
 en	tn	ordinal	18	27
-en	tn	punctuation	25	63
-en	tn	punctuation_match_input	3	13
+en	tn	punctuation	32	63
+en	tn	punctuation_match_input	4	13
 en	tn	range	18	20
 en	tn	roman	3	4
 en	tn	serial	0	32


### PR DESCRIPTION
In TN sentence mode, fold NeMo's double-backtick quotes (`` `` ``) to a straight double quote and add the single backtick to the split-punctuation set. The pretokenizer then splits quotes off the token edges so the **quoted content normalizes** while the quote itself is re-emitted.

- `` ``He's 50 and 2010``. `` → `"He's fifty and twenty ten".`
- `` ``cat``, ``dog`` `` → `"cat", "dog"`
- `` a `25` example `` → `` a `twenty five` example `` (single backticks split off but preserved)

**en TN punctuation parity: 25/63 → 32/63**; punctuation_match_input 3→4. **No regressions** across any language or direction (the ITN pretokenizer also gains the backtick split, harmlessly).

The remaining punctuation fails are an unrelated grab-bag (date-comma preservation, `&`→"and", em-dash ranges, abbreviation collapse, trailing-punct edge cases) — each its own rule, left for follow-ups.

## Tests
- `cargo test` green (added `test_tn_sentence_backtick_quotes`); `cargo fmt --check` + clippy clean on `lib.rs`.
- Parity baseline regenerated (only the two punctuation rows move).

🤖 Generated with [Claude Code](https://claude.com/claude-code)