### PR TITLE
fix(tn/en): stop taggers swallowing trailing sentence punctuation (punctuation 32→34)

### DIFF
--- a/src/tn/en/date.rs
+++ b/src/tn/en/date.rs
@@ -240,9 +240,13 @@ fn parse_day(token: &str) -> Option<u32> {
     (1..=31).contains(&day).then_some(day)
 }
 
-/// Parse a 4-digit year token (trailing punctuation allowed) year-style.
+/// Parse a bare 4-digit year token year-style. Only a trailing period is
+/// tolerated (single-expression input like `"March 8, 2026."` has no
+/// pretokenizer to strip it); other trailing punctuation is rejected so a
+/// sentence-mode date span cannot silently swallow a following ")" or "]"
+/// (the shorter, punctuation-free span wins instead).
 fn parse_year_word(token: &str) -> Option<String> {
-    let t = token.trim().trim_end_matches(|c: char| !c.is_ascii_digit());
+    let t = token.trim().trim_end_matches('.');
     if t.len() == 4 && t.chars().all(|c| c.is_ascii_digit()) {
         return verbalize_year(t.parse().ok()?);
     }

--- a/src/tn/en/electronic.rs
+++ b/src/tn/en/electronic.rs
@@ -46,6 +46,16 @@ pub fn parse(input: &str) -> Option<String> {
         return None;
     }
 
+    // Reject spans padded with sentence punctuation the entity cannot hold
+    // (e.g. a trailing "!" or ")", a leading "("), so the sliding window emits
+    // that punctuation as its own token instead of the tagger silently
+    // dropping it. A trailing "/" is a legitimate URL path separator and kept.
+    let first = trimmed.chars().next().unwrap();
+    let last = trimmed.chars().last().unwrap();
+    if !first.is_ascii_alphanumeric() || (!last.is_ascii_alphanumeric() && last != '/') {
+        return None;
+    }
+
     // "word / word" (spaces optional) reads the slash literally. Handled first
     // so the whitespace guard below can reject spaces in the URL/email forms.
     if let Some(result) = parse_slash_words(trimmed) {
@@ -376,6 +386,17 @@ mod tests {
             parse("ourdailynews.com/12-sm"),
             Some("ourdailynews dot com slash one two dash sm".to_string())
         );
+    }
+
+    #[test]
+    fn test_rejects_trailing_punctuation() {
+        // Sentence punctuation the entity cannot hold is rejected so the
+        // sliding window keeps it as its own token.
+        assert_eq!(parse("test.com!"), None);
+        assert_eq!(parse("me@gmail.com)"), None);
+        assert_eq!(parse("(test.com"), None);
+        // A trailing slash is a legitimate URL path separator.
+        assert!(parse("www.x.com/y/").is_some());
     }
 
     #[test]

--- a/tests/extensive_tests.rs
+++ b/tests/extensive_tests.rs
@@ -1477,6 +1477,28 @@ fn test_tn_sentence_backtick_quotes() {
 }
 
 // ════════════════════════════════════════════════════════════════════════
+// 26c. TN TRAILING-PUNCTUATION PRESERVATION
+// ════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_tn_trailing_punctuation_preserved() {
+    // Taggers must not silently swallow trailing sentence punctuation: the
+    // shorter, punctuation-free span wins and the punctuation emits separately.
+    assert_eq!(
+        tn_normalize_sentence("email me@gmail.com!"),
+        "email me at gmail dot com!"
+    );
+    assert_eq!(
+        tn_normalize_sentence("here (4 June 2014). and"),
+        "here (the fourth of june twenty fourteen). and"
+    );
+    assert_eq!(
+        tn_normalize_sentence("visit test.com, please"),
+        "visit test dot com, please"
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════
 // 27. BUG FIX: i64::MIN OVERFLOW IN number_to_words
 // ════════════════════════════════════════════════════════════════════════
 

--- a/tests/parity_baseline.tsv
+++ b/tests/parity_baseline.tsv
@@ -58,7 +58,7 @@ en	tn	measure	10	21
 en	tn	money	65	71
 en	tn	normalize_with_audio	0	58
 en	tn	ordinal	18	27
-en	tn	punctuation	32	63
+en	tn	punctuation	34	63
 en	tn	punctuation_match_input	4	13
 en	tn	range	18	20
 en	tn	roman	3	4


### PR DESCRIPTION
In TN sentence mode the pretokenizer splits trailing punctuation into its own token, but a tagger that matched a *re-joined* span could silently drop it — and since that lossy span was longer, it beat the clean punctuation-free span.

Two instances found and fixed (money/measure/time/telephone/decimal already preserve trailing punctuation and are untouched):

- **electronic**: reject a span whose first/last char is sentence punctuation the entity cannot hold (a trailing `/` is still allowed as a URL separator). `myemail@gmail.com!` now keeps its `!` instead of `parse_email` dropping it in `render_label`.
- **date**: `parse_year_word` no longer strips *arbitrary* trailing punctuation — only a trailing period (single-expression input like `March 8, 2026.` has no pretokenizer to split it). `here (4 June 2014). and` now keeps `).` instead of the year parse swallowing it.

**en TN punctuation parity: 32/63 → 34/63**; no regressions across any language or direction.

## Tests
- Added `test_rejects_trailing_punctuation` (electronic) and `test_tn_trailing_punctuation_preserved` (sentence-level); the pre-existing single-expr `test_tn_date_trailing_punctuation` (`March 8, 2026.` → date) still passes.
- `cargo test` green; `cargo fmt --check` clean; parity baseline regenerated (only the punctuation row moves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)