### PR TITLE
feat(tn/en/money): per-period rates and US$ prefix (65→71, complete)

### DIFF
--- a/src/tn/en/money.rs
+++ b/src/tn/en/money.rs
@@ -56,6 +56,13 @@ const DOLLAR: Currency = Currency {
     cent_plural: "cents",
 };
 
+const US_DOLLAR: Currency = Currency {
+    singular: "us dollar",
+    plural: "us dollars",
+    cent_singular: "cent",
+    cent_plural: "cents",
+};
+
 const EURO: Currency = Currency {
     singular: "euro",
     plural: "euros",
@@ -94,8 +101,15 @@ pub fn parse(input: &str) -> Option<String> {
         return None;
     }
 
-    // Detect currency symbol
-    let (currency, rest) = if let Some(r) = trimmed.strip_prefix('$') {
+    // Money per period: "$20/mo" → "twenty dollars per month".
+    if let Some(result) = parse_per_period(trimmed) {
+        return Some(result);
+    }
+
+    // Detect currency symbol ("US$" before the bare "$").
+    let (currency, rest) = if let Some(r) = trimmed.strip_prefix("US$") {
+        (&US_DOLLAR, r)
+    } else if let Some(r) = trimmed.strip_prefix('$') {
         (&DOLLAR, r)
     } else if let Some(r) = trimmed.strip_prefix('€') {
         (&EURO, r)
@@ -170,6 +184,23 @@ pub fn parse(input: &str) -> Option<String> {
         };
         Some(format!("{} {}", amount_words(n), unit))
     }
+}
+
+/// Money over a period abbreviation: `$20/mo` → "twenty dollars per month".
+fn parse_per_period(input: &str) -> Option<String> {
+    let (money_part, period) = input.split_once('/')?;
+    let period_word = match period.trim() {
+        "mo" => "month",
+        "yr" => "year",
+        "wk" => "week",
+        "d" => "day",
+        "hr" => "hour",
+        "sec" => "second",
+        "min" => "minute",
+        _ => return None,
+    };
+    let money = parse(money_part.trim())?;
+    Some(format!("{} per {}", money, period_word))
 }
 
 /// Parse `$X.Y`. A fractional part that is a whole number of cents (≤ 2

--- a/tests/data/en/tn_money.txt
+++ b/tests/data/en/tn_money.txt
@@ -63,3 +63,9 @@ $18129~eighteen thousand one hundred and twenty nine dollars
 £2.01~two pounds one penny
 $1,925.21~one thousand nine hundred and twenty five dollars twenty one cents
 $1,234.123~one thousand two hundred and thirty four point one two three dollars
+US$76.3 trillion~seventy six point three trillion us dollars
+$20/mo~twenty dollars per month
+$350/yr~three hundred and fifty dollars per year
+£10/wk~ten pounds per week
+$1/d~one dollar per day
+$0.5/hr~fifty cents per hour

--- a/tests/parity_baseline.tsv
+++ b/tests/parity_baseline.tsv
@@ -55,7 +55,7 @@ en	tn	electronic	40	45
 en	tn	fraction	16	16
 en	tn	math	4	4
 en	tn	measure	10	21
-en	tn	money	65	71
+en	tn	money	71	71
 en	tn	normalize_with_audio	0	58
 en	tn	ordinal	18	27
 en	tn	punctuation	34	63


### PR DESCRIPTION
- `$20/mo` → "twenty dollars per month" (mo/yr/wk/d/hr/sec/min)
- `US$76.3 trillion` → "seventy six point three trillion us dollars"

**en TN money parity: 65/71 → 71/71 (complete).** No regressions. Vendored data + baseline updated; `cargo test`/`fmt` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)