### PR TITLE
feat(tn/en/ordinal): match NeMo on malformed suffixes (18→27, complete)

### DIFF
--- a/src/tn/en/ordinal.rs
+++ b/src/tn/en/ordinal.rs
@@ -13,7 +13,7 @@ pub fn parse(input: &str) -> Option<String> {
     let trimmed = input.trim();
 
     // Detect suffix: st, nd, rd, th
-    let (num_str, _suffix) = if let Some(s) = trimmed.strip_suffix("st") {
+    let (num_str, suffix) = if let Some(s) = trimmed.strip_suffix("st") {
         (s, "st")
     } else if let Some(s) = trimmed.strip_suffix("nd") {
         (s, "nd")
@@ -37,9 +37,34 @@ pub fn parse(input: &str) -> Option<String> {
         return None;
     }
 
+    // Malformed ordinal — the written suffix does not match the number's true
+    // ordinal suffix ("1th", "111st"). NeMo reads the number (cardinal below
+    // 100, digit-by-digit at 100+) and appends the literal suffix as a word.
+    if suffix != correct_suffix(n) {
+        let number = if n < 100 {
+            number_to_words(n)
+        } else {
+            super::spell_digits(&digits)
+        };
+        return Some(format!("{} {}", number, suffix));
+    }
+
     // "0th" → "zeroth" (cardinal_to_ordinal maps the "zero" tail to "zeroth").
     let cardinal = number_to_words(n);
     Some(cardinal_to_ordinal(&cardinal))
+}
+
+/// The correct ordinal suffix for `n` (11–13 are always "th").
+fn correct_suffix(n: i64) -> &'static str {
+    if (11..=13).contains(&(n % 100)) {
+        return "th";
+    }
+    match n % 10 {
+        1 => "st",
+        2 => "nd",
+        3 => "rd",
+        _ => "th",
+    }
 }
 
 /// Spell an integer as ordinal words (`2640` → "two thousand six hundred

--- a/tests/data/en/tn_ordinal.txt
+++ b/tests/data/en/tn_ordinal.txt
@@ -21,3 +21,10 @@
 21st~twenty first
 121st~one hundred twenty first
 111th~one hundred eleventh
+# Malformed suffixes read the number + literal suffix (NeMo).
+1th~one th
+4rd~four rd
+11st~eleven st
+13rd~thirteen rd
+21th~twenty one th
+111st~one one one st

--- a/tests/parity_baseline.tsv
+++ b/tests/parity_baseline.tsv
@@ -57,7 +57,7 @@ en	tn	math	4	4
 en	tn	measure	10	21
 en	tn	money	71	71
 en	tn	normalize_with_audio	0	58
-en	tn	ordinal	18	27
+en	tn	ordinal	27	27
 en	tn	punctuation	34	63
 en	tn	punctuation_match_input	4	13
 en	tn	range	18	20


### PR DESCRIPTION
When the written suffix does not match the number's true ordinal suffix (`1th`, `4rd`, `111st`), NeMo reads the number (cardinal below 100, digit-by-digit at 100+) and appends the literal suffix as a word.

- `1th` → "one th", `21th` → "twenty one th", `111st` → "one one one st"

**en TN ordinal parity: 18/27 → 27/27 (complete).** No regressions. Vendored data + baseline updated; tests/fmt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)