### PR TITLE
feat(parity): score normalize_with_audio's multi-candidate format (en 0→29)

### DIFF
--- a/examples/parity.rs
+++ b/examples/parity.rs
@@ -71,7 +71,7 @@ fn main() {
                     .and_then(|s| s.to_str())
                     .map(|s| s.trim_start_matches("test_cases_").to_string())
                     .unwrap_or_default();
-                let stat = score_file(&path, lang, is_tn);
+                let stat = score_file(&path, lang, is_tn, &class);
                 if stat.total > 0 {
                     stats.insert(format!("{}\t{}\t{}", lang, dir, class), stat);
                 }
@@ -107,8 +107,16 @@ fn main() {
 /// Run every `input~expected` line through the port, counting matches. Each
 /// call is isolated with `catch_unwind` so a panicking input is counted as a
 /// failure instead of aborting the run.
-fn score_file(path: &Path, lang: &str, is_tn: bool) -> Stat {
+fn score_file(path: &Path, lang: &str, is_tn: bool, class: &str) -> Stat {
     let content = fs::read_to_string(path).unwrap_or_default();
+
+    // `normalize_with_audio` uses a multi-candidate format: a `~input` line
+    // followed by one or more acceptable spoken variants. The output passes if
+    // it matches any variant.
+    if class == "normalize_with_audio" {
+        return score_multi_candidate(&content, lang);
+    }
+
     let mut stat = Stat::default();
     for line in content.lines() {
         if line.is_empty() || line.starts_with('#') {
@@ -133,6 +141,37 @@ fn score_file(path: &Path, lang: &str, is_tn: bool) -> Stat {
         });
         match got {
             Ok(g) if g == expected => stat.pass += 1,
+            Ok(_) => {}
+            Err(_) => stat.panics += 1,
+        }
+    }
+    stat
+}
+
+/// Score NeMo's multi-candidate `normalize_with_audio` format: blocks of a
+/// `~input` line plus one or more acceptable variants; pass if the port's
+/// output matches any variant.
+fn score_multi_candidate(content: &str, lang: &str) -> Stat {
+    let mut stat = Stat::default();
+    let mut blocks: Vec<(String, Vec<String>)> = Vec::new();
+    for line in content.lines() {
+        if let Some(rest) = line.strip_prefix('~') {
+            blocks.push((rest.to_string(), Vec::new()));
+        } else if !line.is_empty() {
+            if let Some(last) = blocks.last_mut() {
+                last.1.push(line.to_string());
+            }
+        }
+    }
+    for (input, candidates) in blocks {
+        if candidates.is_empty() {
+            continue;
+        }
+        stat.total += 1;
+        let lang = lang.to_string();
+        let got = panic::catch_unwind(move || tn_normalize_sentence_lang(&input, &lang));
+        match got {
+            Ok(g) if candidates.iter().any(|c| *c == g) => stat.pass += 1,
             Ok(_) => {}
             Err(_) => stat.panics += 1,
         }

--- a/tests/parity_baseline.tsv
+++ b/tests/parity_baseline.tsv
@@ -19,7 +19,7 @@ de	tn	electronic	0	19
 de	tn	fraction	0	34
 de	tn	measure	0	29
 de	tn	money	0	21
-de	tn	normalize_with_audio	0	31
+de	tn	normalize_with_audio	15	31
 de	tn	ordinal	0	19
 de	tn	telephone	0	4
 de	tn	time	0	28
@@ -56,7 +56,7 @@ en	tn	fraction	16	16
 en	tn	math	4	4
 en	tn	measure	10	21
 en	tn	money	71	71
-en	tn	normalize_with_audio	0	58
+en	tn	normalize_with_audio	29	58
 en	tn	ordinal	27	27
 en	tn	punctuation	34	63
 en	tn	punctuation_match_input	4	13
@@ -97,7 +97,7 @@ es	tn	electronic	4	22
 es	tn	fraction	0	75
 es	tn	measure	5	32
 es	tn	money	9	69
-es	tn	normalize_with_audio	0	29
+es	tn	normalize_with_audio	18	29
 es	tn	ordinal	3	120
 es	tn	telephone	0	15
 es	tn	time	1	35


### PR DESCRIPTION
NeMo's `normalize_with_audio` files use a `~input` line followed by one or more **acceptable spoken variants** (for audio-based selection). The parity harness previously mis-parsed each line as `input~expected` and scored the class at ~0. This adds a multi-candidate scorer: a block passes if the port's output matches **any** listed variant.

**en TN `normalize_with_audio`: 0/58 → 29/58** (de 0→15, es 0→18). The remaining fails are serial-style alphanumerics the port does not yet handle (they will improve with the serial class).

Measurement fix only — no normalizer behavior changes. Baseline regenerated (only the three `normalize_with_audio` rows move, all increases); `cargo test`/`fmt` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)