### PR TITLE
feat(tn/en/electronic): port NeMo word-segmentation list (41→43)

### DIFF
--- a/src/tn/en/electronic.rs
+++ b/src/tn/en/electronic.rs
@@ -41,6 +41,31 @@ lazy_static! {
     /// File-extension acronyms upper-cased when they are the final ".ext".
     static ref EXT_UPPER: HashSet<&'static str> =
         ["html", "htm", "xml", "css", "json", "php", "asp", "sql"].into_iter().collect();
+
+    /// Known segments for splitting run-together tokens (NeMo
+    /// electronic/words.tsv).
+    static ref WORDS: HashSet<&'static str> = [
+        "drive", "sim", "early", "access", "program", "rtx", "developer",
+        "basepod", "cuda", "cv", "enterprise", "services", "nvidia", "dgx",
+        "pro", "help",
+    ]
+    .into_iter()
+    .collect();
+}
+
+/// Greedily split `word` into a sequence of two or more known segments, longest
+/// prefix first; returns `None` if it cannot be fully segmented.
+fn segment_words(word: &str) -> Option<Vec<String>> {
+    let mut parts = Vec::new();
+    let mut rest = word;
+    while !rest.is_empty() {
+        let len = (1..=rest.len())
+            .rev()
+            .find(|&len| WORDS.contains(&rest[..len]))?;
+        parts.push(rest[..len].to_string());
+        rest = &rest[len..];
+    }
+    (parts.len() >= 2).then_some(parts)
 }
 
 /// Parse an email or URL to spoken form.
@@ -276,6 +301,24 @@ fn render_label(label: &str, context: bool, is_final_tld: bool) -> String {
 /// Case a pure-alpha token by role.
 fn case_word(word: &str, context: bool, is_final_tld: bool) -> String {
     let lw = word.to_ascii_lowercase();
+
+    // Segment a run-together token into known words ("rtxprohelp" → "RTX pro
+    // help", "enterpriseservices" → "enterprise services").
+    if context && !is_final_tld {
+        if let Some(parts) = segment_words(&lw) {
+            return parts
+                .iter()
+                .map(|p| {
+                    if BRAND.contains(p.as_str()) {
+                        p.to_ascii_uppercase()
+                    } else {
+                        p.clone()
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(" ");
+        }
+    }
 
     // Common file-extension expansion (lower case).
     if lw == "jpg" {

--- a/tests/data/en/tn_electronic.txt
+++ b/tests/data/en/tn_electronic.txt
@@ -3,13 +3,14 @@
 # NeMo's casing (ccTLDs/brands/protocol keywords upper-cased in email/URL
 # context; bare domains stay lower case).
 #
-# Omitted (need NeMo's full data lists / cross-class handling; see the parity
-# baseline for the sentence-mode tally):
-#   - word segmentation:   "rtxprohelp" -> "RTX pro help"
+# Omitted (need cross-class handling; see the parity baseline for the
+# sentence-mode tally):
 #   - cardinal in path:    "rtx-6000"   -> "RTX dash six thousand"
-#   - extension vs dir:    ".html" ext upper-cased but "html" dir lower-cased
 #   - serial digit runs:   bare "8876"  -> "eight eight seven six"
 #   - sentence-only spans: "email is abc1@gmail.com", "... test.com and test2.uk"
+rtxprohelp@exchange.nvidia.com~RTX pro help at exchange dot NVIDIA dot com
+enterpriseservices@nvidia.com~enterprise services at NVIDIA dot com
+file:///c/code/NeMo/docs/build/html/processing/intro.html~file colon slash slash slash c slash code slash nemo slash docs slash build slash html slash processing slash intro dot HTML
 a.bc@gmail.com~a dot bc at gmail dot com
 a@hotmail.de~a at hotmail dot DE
 a@hotmail.fr~a at hotmail dot FR

--- a/tests/parity_baseline.tsv
+++ b/tests/parity_baseline.tsv
@@ -51,7 +51,7 @@ en	tn	address	8	11
 en	tn	cardinal	18	18
 en	tn	date	53	54
 en	tn	decimal	12	12
-en	tn	electronic	41	45
+en	tn	electronic	43	45
 en	tn	fraction	16	16
 en	tn	math	4	4
 en	tn	measure	11	21


### PR DESCRIPTION
Ports NeMo's `electronic/words.tsv` (16 curated segments) and greedily splits run-together email/URL tokens into known words:
- `rtxprohelp` → "RTX pro help"
- `enterpriseservices` → "enterprise services"

Brand segments (`rtx`, `cuda`, `dgx`, …) keep their upper-casing. **en TN electronic: 41/45 → 43/45.** The last two need cross-class handling (cardinal-in-path `rtx-6000`, bare serial `8876`). No regressions; vendored data + baseline updated; tests/fmt/clippy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)