### PR TITLE
feat(tn/en/serial): port NeMo's alnum vs pure digit reading (28→29)

### DIFF
--- a/src/tn/en/serial.rs
+++ b/src/tn/en/serial.rs
@@ -8,9 +8,12 @@
 //! when they carry a leading zero or exceed four digits); `-` and `/` are kept
 //! literally and glue their neighbours, while other symbols spell out as words.
 //!
-//! NeMo's serial grammar is internally inconsistent in places (a hyphen is kept
-//! in "133-ABC" but spaced in "1-8090" and dropped in "7-eleven"); those
-//! irregular forms are not reproduced.
+//! Digit reading follows NeMo's two graphs: a run glued to letters
+//! (num_graph_alnum) reads 1–2 digits / single-then-zeros as a cardinal and a
+//! 3-digit-not-"00" or 4+ run digit-by-digit, while a pure delimiter-separated
+//! group (num_graph_pure) reads up to four digits as a cardinal. A few cases
+//! that route through other graphs (the "card ending in" cc-cue for "8876",
+//! the range-style "1-8090", verbalizer casing for "4s") are not reproduced.
 
 use super::{number_to_words, spell_digits};
 
@@ -71,15 +74,39 @@ pub fn parse(input: &str) -> Option<String> {
         }
     }
 
+    // Render each delimiter-free segment, keeping "-" and "/" literal. A digit
+    // run's reading depends on whether its segment mixes letters (NeMo's
+    // num_graph_alnum) or is a pure numeric group (num_graph_pure).
     let mut out = String::new();
-    let mut chars = token.chars().peekable();
-    while let Some(&c) = chars.peek() {
+    let mut seg = String::new();
+    for c in token.chars() {
         if c == '-' || c == '/' {
-            // Glue: keep literal, no surrounding spaces.
+            render_segment(&seg, &mut out)?;
+            seg.clear();
             out.push(c);
-            chars.next();
-            continue;
+        } else {
+            seg.push(c);
         }
+    }
+    render_segment(&seg, &mut out)?;
+
+    if out == token {
+        return None;
+    }
+    Some(out)
+}
+
+/// Render one delimiter-free segment, appending to `out` with the serial
+/// spacing rules (space between runs, no space after a glue delimiter).
+fn render_segment(seg: &str, out: &mut String) -> Option<()> {
+    if seg.is_empty() {
+        return Some(());
+    }
+    // A segment mixing letters and digits uses NeMo's alnum digit reading;
+    // a pure numeric group uses the delimiter-group reading.
+    let alnum = seg.chars().any(|c| c.is_ascii_alphabetic());
+    let mut chars = seg.chars().peekable();
+    while let Some(&c) = chars.peek() {
         let piece = if c.is_ascii_alphabetic() {
             let mut run = String::new();
             while matches!(chars.peek(), Some(d) if d.is_ascii_alphabetic()) {
@@ -91,7 +118,11 @@ pub fn parse(input: &str) -> Option<String> {
             while matches!(chars.peek(), Some(d) if d.is_ascii_digit()) {
                 run.push(chars.next().unwrap());
             }
-            read_digits(&run)?
+            if alnum {
+                read_alnum_digits(&run)?
+            } else {
+                read_pure_digits(&run)?
+            }
         } else {
             let word = symbol_word(c)?.to_string();
             chars.next();
@@ -102,11 +133,7 @@ pub fn parse(input: &str) -> Option<String> {
         }
         out.push_str(&piece);
     }
-
-    if out == token {
-        return None;
-    }
-    Some(out)
+    Some(())
 }
 
 /// An ARPABET phoneme token: upper-case letters followed by a single stress
@@ -120,13 +147,36 @@ fn is_arpabet(token: &str) -> bool {
     letters.iter().all(|b| b.is_ascii_uppercase()) && matches!(last[0], b'0'..=b'2')
 }
 
-/// Read a digit run: digit-by-digit with a leading zero or beyond four digits,
-/// otherwise a cardinal ("25" → "twenty five", "2000" → "two thousand").
-fn read_digits(run: &str) -> Option<String> {
+/// Read a digit run inside a pure numeric group (delimiter-separated):
+/// digit-by-digit with a leading zero or beyond four digits, otherwise a
+/// cardinal ("133" → "one hundred thirty three", "2021" → "two thousand
+/// twenty one", "261788" → "two six one seven eight eight").
+fn read_pure_digits(run: &str) -> Option<String> {
     if run.starts_with('0') || run.len() > 4 {
         Some(spell_digits(run))
     } else {
         Some(number_to_words(run.parse().ok()?))
+    }
+}
+
+/// Read a digit run glued to letters (NeMo num_graph_alnum): a leading zero
+/// reads digit-by-digit; 1–2 digits or a single non-zero digit followed only
+/// by zeros read as a cardinal ("2000" → "two thousand"); a 3-digit run not
+/// ending in "00", or 4+ digits, reads digit-by-digit ("9453" → "nine four
+/// five three", "321" → "three two one").
+fn read_alnum_digits(run: &str) -> Option<String> {
+    if run.starts_with('0') {
+        return Some(spell_digits(run));
+    }
+    if run.len() <= 2 {
+        return Some(number_to_words(run.parse().ok()?));
+    }
+    let bytes = run.as_bytes();
+    let single_then_zeros = bytes[0] != b'0' && bytes[1..].iter().all(|&b| b == b'0');
+    if single_then_zeros {
+        Some(number_to_words(run.parse().ok()?))
+    } else {
+        Some(spell_digits(run))
     }
 }
 

--- a/tests/parity_baseline.tsv
+++ b/tests/parity_baseline.tsv
@@ -62,7 +62,7 @@ en	tn	punctuation	39	63
 en	tn	punctuation_match_input	4	13
 en	tn	range	19	20
 en	tn	roman	4	4
-en	tn	serial	28	32
+en	tn	serial	29	32
 en	tn	special_text	9	10
 en	tn	telephone	20	20
 en	tn	time	21	21


### PR DESCRIPTION
Reading NeMo's actual `serial.py` grammar shows digit runs use **two** graphs, not one:
- **num_graph_alnum** (run glued to letters): 1–2 digits or a single non-zero digit followed only by zeros → cardinal; a 3-digit run not ending in "00", or 4+ digits → digit-by-digit.
- **num_graph_pure** (pure delimiter-separated group): up to four digits → cardinal.

The port applied one rule to both, so `ab9453` read "nine thousand four hundred fifty three" instead of the correct **"nine four five three"**. This renders per delimiter-free segment and picks the reading by whether the segment mixes letters — a faithful port of the documented rule, not a special-case.

**en TN serial 28→29.** No regressions; `cargo test`/`fmt`/clippy green; baseline updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)