### PR TITLE
feat(tn/en/measure): decimal-dash-unit and decimal-x (11→14)

### DIFF
--- a/src/tn/en/measure.rs
+++ b/src/tn/en/measure.rs
@@ -116,6 +116,12 @@ pub fn parse(input: &str) -> Option<String> {
         return None;
     }
 
+    // Decimal attached to a unit word by a hyphen ("7.2-millimeter") or the "x"
+    // multiplier ("4.4x"), per NeMo's decimal_dash_alpha / decimal_times.
+    if let Some(result) = parse_decimal_unit(trimmed) {
+        return Some(result);
+    }
+
     // Try to find a unit suffix (longest match first)
     // Sort by length descending to match "km/h" before "h"
     let mut unit_matches: Vec<(&str, &UnitInfo)> = UNITS
@@ -224,6 +230,36 @@ fn is_spaced_decade(num: &str) -> bool {
     num.len() == 4
         && num.chars().all(|c| c.is_ascii_digit())
         && num.parse::<u32>().map(|n| n % 10 == 0).unwrap_or(false)
+}
+
+/// Read a decimal glued to a unit word by "-" ("7.2-millimeter" → "seven point
+/// two millimeter") or by the "x" multiplier ("4.4x" → "four point four x").
+/// The trailing word is a spelled-out unit and is kept verbatim.
+fn parse_decimal_unit(input: &str) -> Option<String> {
+    let (num, unit) = if let Some((n, u)) = input.split_once('-') {
+        (n, u.to_string())
+    } else if let Some(n) = input.strip_suffix(['x', 'X']) {
+        (n, "x".to_string())
+    } else {
+        return None;
+    };
+    if unit.is_empty() || !unit.chars().all(|c| c.is_ascii_alphabetic()) {
+        return None;
+    }
+    let (int_str, frac_str) = num.split_once('.')?;
+    if frac_str.is_empty() || !frac_str.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    let clean: String = int_str.chars().filter(|c| *c != ',').collect();
+    if clean.is_empty() || !clean.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    Some(format!(
+        "{} point {} {}",
+        number_to_words_and(clean.parse().ok()?),
+        super::spell_digits(frac_str),
+        unit
+    ))
 }
 
 /// Read a "value/unit" form where the right side is a bare unit.

--- a/tests/data/en/tn_measure.txt
+++ b/tests/data/en/tn_measure.txt
@@ -14,3 +14,5 @@
 1°C~one degree Celsius
 1234-123kg~one thousand two hundred and thirty four to one hundred and twenty three kilograms
 41,459.00 km³~forty one thousand four hundred and fifty nine point zero zero cubic kilometers
+7.2-millimeter~seven point two millimeter
+4.4x~four point four x

--- a/tests/parity_baseline.tsv
+++ b/tests/parity_baseline.tsv
@@ -54,9 +54,9 @@ en	tn	decimal	12	12
 en	tn	electronic	43	45
 en	tn	fraction	16	16
 en	tn	math	4	4
-en	tn	measure	11	21
+en	tn	measure	14	21
 en	tn	money	71	71
-en	tn	normalize_with_audio	39	58
+en	tn	normalize_with_audio	40	58
 en	tn	ordinal	27	27
 en	tn	punctuation	39	63
 en	tn	punctuation_match_input	4	13


### PR DESCRIPTION
Ports NeMo's measure `decimal_dash_alpha` / `decimal_times` rules: a decimal glued to a spelled-out unit word by a hyphen or the `x` multiplier reads the decimal and keeps the unit word verbatim.
- `7.2-millimeter` → "seven point two millimeter"
- `123.2-millimeters` → "one hundred and twenty three point two millimeters"
- `4.4x` → "four point four x"

**en TN measure: 11→14**; normalize_with_audio 39→40. No regressions; vendored data + baseline updated; tests/fmt/clippy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)