### PR TITLE
feat(tn/en/date): "the <day> <month>" consumes the article (53→54, complete)

### DIFF
--- a/src/tn/en/date.rs
+++ b/src/tn/en/date.rs
@@ -32,6 +32,16 @@ pub fn parse(input: &str) -> Option<String> {
         return Some(result);
     }
 
+    // "the 26th May" → "the twenty sixth of may": a British day-month preceded
+    // by "the" consumes that "the" so the reading is not doubled in a sentence.
+    if let Some(rest) = trimmed.strip_prefix("the ") {
+        if let Some(result) = parse_word_date(rest) {
+            if result.starts_with("the ") {
+                return Some(result);
+            }
+        }
+    }
+
     // Try word dates: "January 5, 2025", "jul 25 2012" (US Month-Day) and
     // "25 july 2012" (British Day-Month), with abbreviated/cased months.
     if let Some(result) = parse_word_date(trimmed) {

--- a/tests/parity_baseline.tsv
+++ b/tests/parity_baseline.tsv
@@ -49,7 +49,7 @@ en	itn	word	55	55
 en	itn	word_cased	49	49
 en	tn	address	8	11
 en	tn	cardinal	18	18
-en	tn	date	53	54
+en	tn	date	54	54
 en	tn	decimal	12	12
 en	tn	electronic	43	45
 en	tn	fraction	16	16


### PR DESCRIPTION
A British day-month date preceded by "the" (`the 26th May`) consumes that article, so the reading is not doubled inside a sentence:
`One should go to the store on the 26th May in the evening` → "… on the twenty sixth of may in the evening".

**en TN date: 53/54 → 54/54 (complete).** No regressions; tests/fmt/clippy green; baseline updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)