### PR TITLE
feat(tn): split interior apostrophe so possessives normalize (+2)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1062,7 +1062,7 @@ fn is_split_punct(c: char) -> bool {
 /// never occur inside glued numeric/semiotic forms (unlike `.`/`:`/`,`), so
 /// splitting them cannot break decimals, times, or IPs.
 fn is_interior_hard(c: char) -> bool {
-    matches!(c, '!' | '?' | '(' | ')' | '[' | ']' | '{' | '}')
+    matches!(c, '!' | '?' | '(' | ')' | '[' | ']' | '{' | '}' | '\'')
 }
 
 /// Fold NeMo's double-backtick quotes to a straight double quote so the

--- a/tests/parity_baseline.tsv
+++ b/tests/parity_baseline.tsv
@@ -58,8 +58,8 @@ en	tn	measure	14	21
 en	tn	money	71	71
 en	tn	normalize_with_audio	40	58
 en	tn	ordinal	27	27
-en	tn	punctuation	41	63
-en	tn	punctuation_match_input	5	13
+en	tn	punctuation	42	63
+en	tn	punctuation_match_input	6	13
 en	tn	range	20	20
 en	tn	roman	4	4
 en	tn	serial	29	32


### PR DESCRIPTION
Adds the apostrophe to the interior-split set so possessives normalize: `80's` -> "eighty's" (the number normalizes, the `'s` stays attached).

Contractions are unaffected: the glued reconstruction still matches them as whole tokens with no tagger, so `don't` / `they're` / `I've` / `I'm` stay literal.

**en TN punctuation 41->42; punctuation_match_input 5->6.** No regressions across any class or language; tests/fmt/clippy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
