### PR TITLE
feat(ffi): expose FST-engine TN + bundle it in the xcframework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           key: swift-ffi
       - name: Build static library for Swift
-        run: cargo build --release --features ffi --target aarch64-apple-darwin
+        run: cargo build --release --features "ffi,fst-engine" --target aarch64-apple-darwin
       - name: Run Swift FFI smoke test
         working-directory: swift-test
         run: swift run NemoTest

--- a/build-xcframework.sh
+++ b/build-xcframework.sh
@@ -12,16 +12,16 @@ rm -rf "$BUILD_DIR" "$OUTPUT_DIR"
 mkdir -p "$BUILD_DIR" "$OUTPUT_DIR"
 
 echo "Building for macOS (arm64)..."
-cargo build --release --features ffi --target aarch64-apple-darwin
+cargo build --release --features "ffi,fst-engine" --target aarch64-apple-darwin
 
 echo "Building for macOS (x86_64)..."
-cargo build --release --features ffi --target x86_64-apple-darwin
+cargo build --release --features "ffi,fst-engine" --target x86_64-apple-darwin
 
 echo "Building for iOS (arm64)..."
-cargo build --release --features ffi --target aarch64-apple-ios
+cargo build --release --features "ffi,fst-engine" --target aarch64-apple-ios
 
 echo "Building for iOS Simulator (arm64)..."
-cargo build --release --features ffi --target aarch64-apple-ios-sim
+cargo build --release --features "ffi,fst-engine" --target aarch64-apple-ios-sim
 
 echo "Creating universal macOS library..."
 mkdir -p "$BUILD_DIR/macos"

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -427,6 +427,58 @@ pub unsafe extern "C" fn nemo_tn_normalize_sentence_with_max_span_lang(
     }
 }
 
+/// Byte-exact NeMo TN via the compiled-FST engine, for `lang` in
+/// {en, zh, ja, fr, es, de, hi}.
+///
+/// Returns `NULL` when the crate was built without the `fst-engine` feature or
+/// the language is unsupported, so callers can fall back to the rule-based
+/// `nemo_tn_normalize_lang`. The ABI is stable regardless of the feature.
+///
+/// # Safety
+/// - `input` and `lang` must be valid null-terminated UTF-8 strings
+/// - Returns a newly allocated string that must be freed with `nemo_free_string`
+#[no_mangle]
+pub unsafe extern "C" fn nemo_tn_fst(input: *const c_char, lang: *const c_char) -> *mut c_char {
+    if input.is_null() || lang.is_null() {
+        return ptr::null_mut();
+    }
+    let input_str = match CStr::from_ptr(input).to_str() {
+        Ok(s) => s,
+        Err(_) => return ptr::null_mut(),
+    };
+    let lang_str = match CStr::from_ptr(lang).to_str() {
+        Ok(s) => s,
+        Err(_) => return ptr::null_mut(),
+    };
+    match fst_normalize(input_str, lang_str) {
+        Some(result) => match CString::new(result) {
+            Ok(c_string) => c_string.into_raw(),
+            Err(_) => ptr::null_mut(),
+        },
+        None => ptr::null_mut(),
+    }
+}
+
+#[cfg(feature = "fst-engine")]
+fn fst_normalize(input: &str, lang: &str) -> Option<String> {
+    use crate::fst;
+    Some(match lang {
+        "en" => fst::en::normalize(input),
+        "zh" => fst::zh::normalize(input),
+        "ja" => fst::ja::normalize(input),
+        "fr" => fst::fr::normalize(input),
+        "es" => fst::es::normalize(input),
+        "de" => fst::de::normalize(input),
+        "hi" => fst::hi::normalize(input),
+        _ => return None,
+    })
+}
+
+#[cfg(not(feature = "fst-engine"))]
+fn fst_normalize(_input: &str, _lang: &str) -> Option<String> {
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -440,6 +492,23 @@ mod tests {
             let result_str = CStr::from_ptr(result).to_str().unwrap();
             assert_eq!(result_str, "200");
             nemo_free_string(result);
+        }
+    }
+
+    #[cfg(feature = "fst-engine")]
+    #[test]
+    fn test_ffi_tn_fst() {
+        unsafe {
+            let input = CString::new("$2").unwrap();
+            let en = CString::new("en").unwrap();
+            let result = nemo_tn_fst(input.as_ptr(), en.as_ptr());
+            assert!(!result.is_null());
+            assert_eq!(CStr::from_ptr(result).to_str().unwrap(), "two dollars");
+            nemo_free_string(result);
+
+            // Unsupported language → NULL (caller falls back to rule-based).
+            let bad = CString::new("xx").unwrap();
+            assert!(nemo_tn_fst(input.as_ptr(), bad.as_ptr()).is_null());
         }
     }
 

--- a/swift-test/Sources/CNemoTextProcessing/include/nemo_text_processing.h
+++ b/swift-test/Sources/CNemoTextProcessing/include/nemo_text_processing.h
@@ -32,6 +32,9 @@ char* nemo_tn_normalize(const char* input);
 char* nemo_tn_normalize_sentence(const char* input);
 char* nemo_tn_normalize_sentence_with_max_span(const char* input, uint32_t max_span_tokens);
 
+/* Byte-exact NeMo TN via the compiled-FST engine (NULL if unavailable) */
+char* nemo_tn_fst(const char* input, const char* lang);
+
 #ifdef __cplusplus
 }
 #endif

--- a/swift-test/Sources/NemoTest/NemoTest.swift
+++ b/swift-test/Sources/NemoTest/NemoTest.swift
@@ -59,6 +59,14 @@ enum NemoTextProcessing {
         return String(cString: resultPtr)
     }
 
+    /// Byte-exact NeMo TN via the FST engine. Returns nil when the library was
+    /// built without the fst-engine feature or the language is unsupported.
+    static func tnFst(_ input: String, _ lang: String) -> String? {
+        guard let resultPtr = nemo_tn_fst(input, lang) else { return nil }
+        defer { nemo_free_string(resultPtr) }
+        return String(cString: resultPtr)
+    }
+
     static func tnNormalizeSentence(_ input: String, maxSpanTokens: UInt32) -> String {
         guard let resultPtr = nemo_tn_normalize_sentence_with_max_span(input, maxSpanTokens) else { return input }
         defer { nemo_free_string(resultPtr) }
@@ -418,6 +426,41 @@ struct NemoTest {
             overall.passed += cr.passed
             overall.failed += cr.failed
             overall.failures += cr.failures
+        }
+
+        // FST engine (byte-exact NeMo parity), if built with --features fst-engine
+        if filterCategory == nil || "fst".hasPrefix(filterCategory!.lowercased()) {
+            if NemoTextProcessing.tnFst("$2", "en") == nil {
+                print("  FST Engine")
+                print("    SKIP (built without fst-engine feature)")
+                print()
+            } else {
+                print("  FST Engine")
+                var fr = TestResults()
+                let fstCases: [(String, String, String)] = [
+                    ("en", "$2", "two dollars"),
+                    ("zh", "2024年", "二零二四年"),
+                    ("ja", "1", "一"),
+                    ("fr", "83", "quatre-vingt-trois"),
+                    ("de", "1", "eins"),
+                ]
+                for (lang, input, expected) in fstCases {
+                    let got = NemoTextProcessing.tnFst(input, lang) ?? "<nil>"
+                    if got == expected {
+                        fr.passed += 1
+                    } else {
+                        fr.failed += 1
+                        fr.failures.append(("FST Engine", "\(lang):\(input)", expected, got))
+                        print("    FAIL \(lang) \"\(input)\" -> \"\(got)\" (expected \"\(expected)\")")
+                    }
+                }
+                let mark = fr.failed == 0 ? "PASS" : "FAIL"
+                print("    \(mark) \(fr.passed)/\(fr.total)")
+                print()
+                overall.passed += fr.passed
+                overall.failed += fr.failed
+                overall.failures += fr.failures
+            }
         }
 
         // Summary

--- a/swift/include/nemo_text_processing.h
+++ b/swift/include/nemo_text_processing.h
@@ -162,6 +162,19 @@ char* nemo_tn_normalize_sentence_lang(const char* input, const char* lang);
 char* nemo_tn_normalize_sentence_with_max_span_lang(const char* input, const char* lang, uint32_t max_span_tokens);
 
 /**
+ * Text Normalization via the compiled-FST engine — byte-exact NeMo parity.
+ *
+ * Supported langs: "en", "zh", "ja", "fr", "es", "de", "hi".
+ * Returns NULL if the library was built without the fst-engine feature or the
+ * language is unsupported, so callers can fall back to nemo_tn_normalize_lang.
+ *
+ * @param input Null-terminated UTF-8 string
+ * @param lang Null-terminated language code
+ * @return Newly allocated string (free with nemo_free_string), or NULL.
+ */
+char* nemo_tn_fst(const char* input, const char* lang);
+
+/**
  * Free a string allocated by nemo_normalize or nemo_normalize_sentence.
  *
  * @param s Pointer returned by nemo_normalize, or NULL (no-op)


### PR DESCRIPTION
## Summary

Makes the byte-exact FST TN engine reachable from Swift/C — the enabling step for wiring it into FluidAudio TTS.

Adds **`nemo_tn_fst(input, lang)`** for en/zh/ja/fr/es/de/hi. **Stable ABI:** the symbol always exists and returns `NULL` when the crate is built without `fst-engine` or the language is unsupported, so callers can fall back to `nemo_tn_normalize_lang`.

## Changes

- `src/ffi.rs`: `nemo_tn_fst` + feature-gated dispatch to `fst::<lang>::normalize`; Rust FFI test (en → "two dollars", unsupported lang → NULL).
- `build-xcframework.sh`: build all four Apple targets with `"ffi,fst-engine"` so the distributed xcframework carries the engine + grammars.
- Headers (`swift/include`, swift-test): declare `nemo_tn_fst`.
- `swift-test`: `tnFst` wrapper + a 5-language FST smoke group that **self-skips** if the lib was built without the feature. The CI `swift-ffi` job now builds with `fst-engine`, so it exercises the full **Swift → FFI → FST** path.

## Verification

- **iOS cross-compile derisked:** `libtext_processing_rs.a` builds for `aarch64-apple-ios` with `fst-engine` (17 MB static lib — rustfst + flate2 + grammars archived in).
- **Swift smoke test PASS 5/5** (en/zh/ja/fr/de) locally.
- Feature-off build is ABI-stable (`nemo_tn_fst` present, returns NULL).
- clippy + `cargo fmt` clean.

## Next (FluidAudio side, separate)

Consume the xcframework as an SPM binaryTarget and call `nemo_tn_fst` at the top of `KokoroAneManager.phonemes(for:)` — en→"en", mandarin→"zh" — before G2P.