### PR TITLE
chore: release 0.3.0 — FST engine (7 langs) + nemo_tn_fst FFI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "text-processing-rs"
-version = "0.2.5"
+version = "0.3.0"
 dependencies = [
  "console_error_panic_hook",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "text-processing-rs"
-version = "0.2.5"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Inverse Text Normalization (ITN) — convert spoken-form ASR output to written form"


### PR DESCRIPTION
Version bump 0.2.5 → 0.3.0 to cut the release whose xcframework carries the FST engine.

Since 0.2.5:
- #76/#77/#78: byte-exact NeMo TN via the compiled-FST engine for all 7 languages (zh, ja, fr, es, de, en, hi) behind the `fst-engine` feature.
- #79: `nemo_tn_fst(input, lang)` FFI + `fst-engine` bundled into the xcframework build.

Tagging `v0.3.0` after merge triggers the xcframework release-upload (now built with `ffi,fst-engine`), producing `NemoTextProcessing.xcframework.zip` + checksum for FluidAudio's SPM binaryTarget.